### PR TITLE
Refine git config handling for use command

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -44,13 +44,18 @@ func TestFullWorkflow(t *testing.T) {
 
 	// Create a mock SSH implementation
 	mockSSH := new(MockSSH)
-	
+
 	// Save original SSH client
 	oldSSHClient := multigit.SSHClient
+	oldSSHAddToAgent := cmd.SSHAddToAgentFunc
 	// Replace with our mock
 	multigit.SSHClient = mockSSH
+	cmd.SSHAddToAgentFunc = func(string) error { return nil }
 	// Restore original client after test
-	defer func() { multigit.SSHClient = oldSSHClient }()
+	defer func() {
+		multigit.SSHClient = oldSSHClient
+		cmd.SSHAddToAgentFunc = oldSSHAddToAgent
+	}()
 
 	// Initialize config
 	cmd.InitConfig()
@@ -200,13 +205,18 @@ func TestErrorConditions(t *testing.T) {
 
 	// Create a mock SSH implementation
 	mockSSH := new(MockSSH)
-	
+
 	// Save original SSH client
 	oldSSHClient := multigit.SSHClient
+	oldSSHAddToAgent := cmd.SSHAddToAgentFunc
 	// Replace with our mock
 	multigit.SSHClient = mockSSH
+	cmd.SSHAddToAgentFunc = func(string) error { return nil }
 	// Restore original client after test
-	defer func() { multigit.SSHClient = oldSSHClient }()
+	defer func() {
+		multigit.SSHClient = oldSSHClient
+		cmd.SSHAddToAgentFunc = oldSSHAddToAgent
+	}()
 
 	// Initialize config
 	cmd.InitConfig()
@@ -215,7 +225,7 @@ func TestErrorConditions(t *testing.T) {
 	t.Run("CreateAccountWithInvalidEmail", func(t *testing.T) {
 		// Initialize config
 		cmd.InitConfig()
-		
+
 		// Capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
@@ -225,7 +235,7 @@ func TestErrorConditions(t *testing.T) {
 		// Execute create command with invalid email
 		cmd.RootCmd.SetArgs([]string{"create", "test-account", "invalid-email"})
 		err := cmd.RootCmd.Execute()
-		
+
 		// Read command output (for debugging purposes)
 		w.Close()
 		var buf bytes.Buffer
@@ -243,7 +253,7 @@ func TestErrorConditions(t *testing.T) {
 	t.Run("UseNonExistentAccount", func(t *testing.T) {
 		// Initialize config
 		cmd.InitConfig()
-		
+
 		// Capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
@@ -253,7 +263,7 @@ func TestErrorConditions(t *testing.T) {
 		// Execute use command with non-existent account
 		cmd.RootCmd.SetArgs([]string{"use", "non-existent-account"})
 		err := cmd.RootCmd.Execute()
-		
+
 		// Read command output (for debugging purposes)
 		w.Close()
 		var buf bytes.Buffer
@@ -270,7 +280,7 @@ func TestErrorConditions(t *testing.T) {
 	t.Run("DeleteNonExistentAccount", func(t *testing.T) {
 		// Initialize config
 		cmd.InitConfig()
-		
+
 		// Capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
@@ -280,7 +290,7 @@ func TestErrorConditions(t *testing.T) {
 		// Execute delete command with non-existent account
 		cmd.RootCmd.SetArgs([]string{"delete", "non-existent-account", "-f"})
 		err := cmd.RootCmd.Execute()
-		
+
 		// Read command output (for debugging purposes)
 		w.Close()
 		var buf bytes.Buffer
@@ -297,7 +307,7 @@ func TestErrorConditions(t *testing.T) {
 	t.Run("CreateDuplicateAccount", func(t *testing.T) {
 		// Initialize config
 		cmd.InitConfig()
-		
+
 		// Setup mock expectations for first create
 		mockSSH.On("CreateSSHKey", "duplicate-account", "test@example.com", "", ssh.KeyTypeED25519).Return(nil)
 		mockSSH.On("AddSSHKeyToAgent", "duplicate-account").Return(nil)
@@ -317,7 +327,7 @@ func TestErrorConditions(t *testing.T) {
 		// Try to create duplicate account
 		cmd.RootCmd.SetArgs([]string{"create", "duplicate-account", "another@example.com"})
 		err = cmd.RootCmd.Execute()
-		
+
 		// Read command output (for debugging purposes)
 		w.Close()
 		var buf bytes.Buffer

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/cpuix/multigit/internal/multigit"
 	"github.com/cpuix/multigit/internal/ssh"
@@ -50,7 +51,7 @@ This will:
 		}
 
 		// Set git config
-		if err := setGitConfig(account, useLocal); err != nil {
+		if err := setGitConfig(accountName, account, useLocal); err != nil {
 			return fmt.Errorf("failed to set git config: %w", err)
 		}
 
@@ -66,7 +67,7 @@ This will:
 }
 
 // setGitConfig sets the git user name and email (global or local)
-func setGitConfig(account multigit.Account, local bool) error {
+func setGitConfig(accountName string, account multigit.Account, local bool) error {
 	// Prepare git config args
 	configArgs := []string{"config"}
 	if !local {
@@ -90,17 +91,47 @@ func setGitConfig(account multigit.Account, local bool) error {
 	}
 
 	// Set push default to current
-	if err := RunGitCommand("config", "--global", "push.default", "current"); err != nil {
+	if err := RunGitCommand(append(configArgs, "push.default", "current")...); err != nil {
 		return fmt.Errorf("failed to set git push.default: %w", err)
 	}
 
+	// Resolve the SSH key path, preferring ED25519
+	keyPath, err := resolveSSHKeyPath(accountName)
+	if err != nil {
+		return fmt.Errorf("failed to resolve SSH key path: %w", err)
+	}
+
 	// Set github.com to use the correct SSH key
-	sshCommand := fmt.Sprintf("ssh -i ~/.ssh/id_rsa_%s -F /dev/null", account.Name)
-	if err := RunGitCommand("config", "--global", "core.sshCommand", sshCommand); err != nil {
+	sshCommand := fmt.Sprintf("ssh -i %s -F /dev/null", keyPath)
+	if err := RunGitCommand(append(configArgs, "core.sshCommand", sshCommand)...); err != nil {
 		return fmt.Errorf("failed to set git core.sshCommand: %w", err)
 	}
 
 	return nil
+}
+
+func resolveSSHKeyPath(accountName string) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine home directory: %w", err)
+	}
+
+	sshDir := filepath.Join(homeDir, ".ssh")
+	keyCandidates := []string{
+		filepath.Join(sshDir, fmt.Sprintf("id_ed25519_%s", accountName)),
+		filepath.Join(sshDir, fmt.Sprintf("id_rsa_%s", accountName)),
+	}
+
+	for _, keyPath := range keyCandidates {
+		if _, err := os.Stat(keyPath); err == nil {
+			return keyPath, nil
+		} else if err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("failed to access SSH key %s: %w", keyPath, err)
+		}
+	}
+
+	// Default to the preferred ED25519 path if no key was found
+	return keyCandidates[0], nil
 }
 
 // RunGitCommand is a variable that holds the function to run git commands

--- a/cmd/use_test.go
+++ b/cmd/use_test.go
@@ -1,6 +1,7 @@
 package cmd_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,14 +15,15 @@ import (
 
 // testUseCommand is a test helper that sets up the test environment for the use command
 type testUseCommand struct {
-	gitCommands []string
+	gitCommands [][]string
 	isGitRepo   bool
 	t           *testing.T
 }
 
 // mockRunGitCommand mocks the RunGitCommand function for testing
 func (tuc *testUseCommand) mockRunGitCommand(args ...string) error {
-	tuc.gitCommands = append(tuc.gitCommands, args[0])
+	copied := append([]string(nil), args...)
+	tuc.gitCommands = append(tuc.gitCommands, copied)
 	tuc.t.Logf("git command: %v", args)
 	return nil
 }
@@ -35,8 +37,6 @@ func (tuc *testUseCommand) mockIsGitRepo() bool {
 // save original functions for restoration
 var originalRunGitCommand = cmd.RunGitCommand
 var originalIsGitRepo = cmd.IsGitRepo
-
-
 
 // TestUseCommand tests the use command
 func TestUseCommand(t *testing.T) {
@@ -78,7 +78,7 @@ func TestUseCommand(t *testing.T) {
 	require.NoError(t, os.MkdirAll(sshDir, 0700))
 
 	// Create a test SSH key
-	testSSHKeyPath := filepath.Join(sshDir, "id_rsa_test-account")
+	testSSHKeyPath := filepath.Join(sshDir, "id_ed25519_test-account")
 	require.NoError(t, os.WriteFile(testSSHKeyPath, []byte("dummy key"), 0600))
 
 	// Initialize a new config
@@ -109,13 +109,13 @@ func TestUseCommand(t *testing.T) {
 
 	// Test cases
 	tests := []struct {
-		name        string
-		args        []string
-		setup       func()
-		local       bool
-		expectCmds  int
-		expectError bool
-		errMsg      string
+		name         string
+		args         []string
+		setup        func()
+		local        bool
+		expectedCmds [][]string
+		expectError  bool
+		errMsg       string
 	}{
 		{
 			name: "Switch to existing account",
@@ -129,8 +129,14 @@ func TestUseCommand(t *testing.T) {
 				}
 				require.NoError(t, multigit.SaveConfig(config))
 			},
-			local:       false,
-			expectCmds:  5, // Expect 5 git config commands for global config
+			local: false,
+			expectedCmds: [][]string{
+				{"config", "--global", "user.name", "Test User"},
+				{"config", "--global", "user.email", "test@example.com"},
+				{"config", "--global", "url.ssh://git@github.com/.insteadOf", "https://github.com/"},
+				{"config", "--global", "push.default", "current"},
+				{"config", "--global", "core.sshCommand", fmt.Sprintf("ssh -i %s -F /dev/null", filepath.Join(tempDir, ".ssh", "id_ed25519_test-account"))},
+			},
 			expectError: false,
 		},
 		{
@@ -145,8 +151,13 @@ func TestUseCommand(t *testing.T) {
 				}
 				require.NoError(t, multigit.SaveConfig(config))
 			},
-			local:       true,
-			expectCmds:  4, // Expect 4 git config commands for local config
+			local: true,
+			expectedCmds: [][]string{
+				{"config", "user.name", "Test User"},
+				{"config", "user.email", "test@example.com"},
+				{"config", "push.default", "current"},
+				{"config", "core.sshCommand", fmt.Sprintf("ssh -i %s -F /dev/null", filepath.Join(tempDir, ".ssh", "id_ed25519_test-account"))},
+			},
 			expectError: false,
 		},
 		{
@@ -158,10 +169,10 @@ func TestUseCommand(t *testing.T) {
 				delete(config.Accounts, "nonexistent")
 				require.NoError(t, multigit.SaveConfig(config))
 			},
-			local:       false,
-			expectCmds:  0, // Expect no git commands
-			expectError: true,
-			errMsg:      "account 'nonexistent' does not exist",
+			local:        false,
+			expectedCmds: nil,
+			expectError:  true,
+			errMsg:       "account 'nonexistent' does not exist",
 		},
 	}
 
@@ -196,15 +207,9 @@ func TestUseCommand(t *testing.T) {
 
 			// Verify the correct git commands were called
 			if !tt.expectError {
-				// Verify that git config was called with the correct arguments
-				assert.Equal(t, tt.expectCmds, len(tuc.gitCommands), "Expected %d git commands, got %d", tt.expectCmds, len(tuc.gitCommands))
-				// Verify all commands are 'config' commands
-				for _, cmd := range tuc.gitCommands {
-					assert.Equal(t, "config", cmd, "Expected 'config' command, got %s", cmd)
-				}
+				assert.Equal(t, tt.expectedCmds, tuc.gitCommands, "Unexpected git commands executed")
 			} else {
-				// Verify no git commands were called
-				assert.Equal(t, tt.expectCmds, len(tuc.gitCommands), "Expected %d git commands, got %d", tt.expectCmds, len(tuc.gitCommands))
+				assert.Len(t, tuc.gitCommands, 0, "No git commands should be executed when an error occurs")
 			}
 
 			// Verify results


### PR DESCRIPTION
## Summary
- update `setGitConfig` to resolve ED25519 keys first and respect the local flag when configuring `push.default` and `core.sshCommand`
- expand the `use` command tests to assert the full git command sequences for global and local runs with ED25519 keys
- stub SSH agent interactions in integration tests to keep the workflow and error coverage exercising the command paths without external dependencies

## Testing
- go test ./cmd -run TestUseCommand -v


------
https://chatgpt.com/codex/tasks/task_e_68cbe26bd25c832aaf893812dab0ff88