### PR TITLE
Finalize passphrase-protected SSH key support

### DIFF
--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -19,8 +19,8 @@ type MockSSH struct {
 }
 
 // CreateSSHKey mocks the CreateSSHKey function
-func (m *MockSSH) CreateSSHKey(accountName, email, passphrase string, keyType ssh.KeyType) error {
-	args := m.Called(accountName, email, passphrase, keyType)
+func (m *MockSSH) CreateSSHKey(accountName, email, passphrase string, keyType ssh.KeyType, keyFileOverride *string) error {
+	args := m.Called(accountName, email, passphrase, keyType, keyFileOverride)
 	return args.Error(0)
 }
 
@@ -92,7 +92,7 @@ func TestCreateAccount(t *testing.T) {
 			passphrase:  "",
 			setup:       func() {},
 			mockSetup: func(m *MockSSH) {
-				m.On("CreateSSHKey", "new-account", "new@example.com", "", ssh.KeyTypeED25519).Return(nil)
+				m.On("CreateSSHKey", "new-account", "new@example.com", "", ssh.KeyTypeED25519, (*string)(nil)).Return(nil)
 				m.On("AddSSHKeyToAgent", "new-account").Return(nil)
 				m.On("AddSSHConfigEntry", "new-account").Return(nil)
 			},
@@ -106,7 +106,7 @@ func TestCreateAccount(t *testing.T) {
 			passphrase:  "my-secure-passphrase",
 			setup:       func() {},
 			mockSetup: func(m *MockSSH) {
-				m.On("CreateSSHKey", "secure-account", "secure@example.com", "my-secure-passphrase", ssh.KeyTypeED25519).Return(nil)
+				m.On("CreateSSHKey", "secure-account", "secure@example.com", "my-secure-passphrase", ssh.KeyTypeED25519, (*string)(nil)).Return(nil)
 				m.On("AddSSHKeyToAgent", "secure-account").Return(nil)
 				m.On("AddSSHConfigEntry", "secure-account").Return(nil)
 			},
@@ -139,7 +139,7 @@ func TestCreateAccount(t *testing.T) {
 			email:       "fail-key@example.com",
 			setup:       func() {},
 			mockSetup: func(m *MockSSH) {
-				m.On("CreateSSHKey", "fail-key-account", "fail-key@example.com", "", ssh.KeyTypeED25519).
+				m.On("CreateSSHKey", "fail-key-account", "fail-key@example.com", "", ssh.KeyTypeED25519, (*string)(nil)).
 					Return(fmt.Errorf("ssh key creation failed"))
 			},
 			expectError: true,
@@ -152,7 +152,7 @@ func TestCreateAccount(t *testing.T) {
 			email:       "fail-agent@example.com",
 			setup:       func() {},
 			mockSetup: func(m *MockSSH) {
-				m.On("CreateSSHKey", "fail-agent-account", "fail-agent@example.com", "", ssh.KeyTypeED25519).Return(nil)
+				m.On("CreateSSHKey", "fail-agent-account", "fail-agent@example.com", "", ssh.KeyTypeED25519, (*string)(nil)).Return(nil)
 				m.On("AddSSHKeyToAgent", "fail-agent-account").
 					Return(fmt.Errorf("failed to add to agent"))
 			},
@@ -166,7 +166,7 @@ func TestCreateAccount(t *testing.T) {
 			email:       "fail-config@example.com",
 			setup:       func() {},
 			mockSetup: func(m *MockSSH) {
-				m.On("CreateSSHKey", "fail-config-account", "fail-config@example.com", "", ssh.KeyTypeED25519).Return(nil)
+				m.On("CreateSSHKey", "fail-config-account", "fail-config@example.com", "", ssh.KeyTypeED25519, (*string)(nil)).Return(nil)
 				m.On("AddSSHKeyToAgent", "fail-config-account").Return(nil)
 				m.On("AddSSHConfigEntry", "fail-config-account").
 					Return(fmt.Errorf("failed to add config entry"))

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -23,6 +23,8 @@ This will:
 4. Remove the account from the multigit config`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		defer func() { forceDelete = false }()
+
 		accountName := args[0]
 
 		// Confirm before deleting
@@ -50,5 +52,5 @@ This will:
 
 func init() {
 	RootCmd.AddCommand(deleteCmd)
-	deleteCmd.Flags().BoolP("force", "f", false, "Force deletion without confirmation")
+	deleteCmd.Flags().BoolVarP(&forceDelete, "force", "f", false, "Force deletion without confirmation")
 }

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -42,9 +42,21 @@ func TestFullWorkflow(t *testing.T) {
 		cmd.CfgFile = oldCfgFile
 	}()
 
+	oldAddToAgent := cmd.SSHAddToAgentFunc
+	cmd.SSHAddToAgentFunc = func(accountName string) error {
+		return nil
+	}
+	defer func() { cmd.SSHAddToAgentFunc = oldAddToAgent }()
+
+	oldRunGit := cmd.RunGitCommand
+	cmd.RunGitCommand = func(args ...string) error {
+		return nil
+	}
+	defer func() { cmd.RunGitCommand = oldRunGit }()
+
 	// Create a mock SSH implementation
 	mockSSH := new(MockSSH)
-	
+
 	// Save original SSH client
 	oldSSHClient := multigit.SSHClient
 	// Replace with our mock
@@ -56,7 +68,7 @@ func TestFullWorkflow(t *testing.T) {
 	cmd.InitConfig()
 
 	// Setup mock expectations for create command
-	mockSSH.On("CreateSSHKey", "test-account", "test@example.com", "", ssh.KeyTypeED25519).Return(nil)
+	mockSSH.On("CreateSSHKey", "test-account", "test@example.com", "", ssh.KeyTypeED25519, (*string)(nil)).Return(nil)
 	mockSSH.On("AddSSHKeyToAgent", "test-account").Return(nil)
 	mockSSH.On("AddSSHConfigEntry", "test-account").Return(nil)
 
@@ -198,9 +210,21 @@ func TestErrorConditions(t *testing.T) {
 		cmd.CfgFile = oldCfgFile
 	}()
 
+	oldAddToAgent := cmd.SSHAddToAgentFunc
+	cmd.SSHAddToAgentFunc = func(accountName string) error {
+		return nil
+	}
+	defer func() { cmd.SSHAddToAgentFunc = oldAddToAgent }()
+
+	oldRunGit := cmd.RunGitCommand
+	cmd.RunGitCommand = func(args ...string) error {
+		return nil
+	}
+	defer func() { cmd.RunGitCommand = oldRunGit }()
+
 	// Create a mock SSH implementation
 	mockSSH := new(MockSSH)
-	
+
 	// Save original SSH client
 	oldSSHClient := multigit.SSHClient
 	// Replace with our mock
@@ -215,7 +239,7 @@ func TestErrorConditions(t *testing.T) {
 	t.Run("CreateAccountWithInvalidEmail", func(t *testing.T) {
 		// Initialize config
 		cmd.InitConfig()
-		
+
 		// Capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
@@ -225,7 +249,7 @@ func TestErrorConditions(t *testing.T) {
 		// Execute create command with invalid email
 		cmd.RootCmd.SetArgs([]string{"create", "test-account", "invalid-email"})
 		err := cmd.RootCmd.Execute()
-		
+
 		// Read command output (for debugging purposes)
 		w.Close()
 		var buf bytes.Buffer
@@ -243,7 +267,7 @@ func TestErrorConditions(t *testing.T) {
 	t.Run("UseNonExistentAccount", func(t *testing.T) {
 		// Initialize config
 		cmd.InitConfig()
-		
+
 		// Capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
@@ -253,7 +277,7 @@ func TestErrorConditions(t *testing.T) {
 		// Execute use command with non-existent account
 		cmd.RootCmd.SetArgs([]string{"use", "non-existent-account"})
 		err := cmd.RootCmd.Execute()
-		
+
 		// Read command output (for debugging purposes)
 		w.Close()
 		var buf bytes.Buffer
@@ -270,7 +294,7 @@ func TestErrorConditions(t *testing.T) {
 	t.Run("DeleteNonExistentAccount", func(t *testing.T) {
 		// Initialize config
 		cmd.InitConfig()
-		
+
 		// Capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
@@ -280,7 +304,7 @@ func TestErrorConditions(t *testing.T) {
 		// Execute delete command with non-existent account
 		cmd.RootCmd.SetArgs([]string{"delete", "non-existent-account", "-f"})
 		err := cmd.RootCmd.Execute()
-		
+
 		// Read command output (for debugging purposes)
 		w.Close()
 		var buf bytes.Buffer
@@ -297,9 +321,9 @@ func TestErrorConditions(t *testing.T) {
 	t.Run("CreateDuplicateAccount", func(t *testing.T) {
 		// Initialize config
 		cmd.InitConfig()
-		
+
 		// Setup mock expectations for first create
-		mockSSH.On("CreateSSHKey", "duplicate-account", "test@example.com", "", ssh.KeyTypeED25519).Return(nil)
+		mockSSH.On("CreateSSHKey", "duplicate-account", "test@example.com", "", ssh.KeyTypeED25519, (*string)(nil)).Return(nil)
 		mockSSH.On("AddSSHKeyToAgent", "duplicate-account").Return(nil)
 		mockSSH.On("AddSSHConfigEntry", "duplicate-account").Return(nil)
 
@@ -317,7 +341,7 @@ func TestErrorConditions(t *testing.T) {
 		// Try to create duplicate account
 		cmd.RootCmd.SetArgs([]string{"create", "duplicate-account", "another@example.com"})
 		err = cmd.RootCmd.Execute()
-		
+
 		// Read command output (for debugging purposes)
 		w.Close()
 		var buf bytes.Buffer

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -12,7 +12,7 @@ import (
 
 // SSHCreateFunc is a function type for creating SSH keys
 var SSHCreateFunc = func(accountName, email, passphrase string, keyType ssh.KeyType) error {
-	return ssh.CreateSSHKey(accountName, email, passphrase, keyType)
+	return ssh.CreateSSHKey(accountName, email, passphrase, keyType, nil)
 }
 
 // SSHAddToAgentFunc is a function type for adding SSH keys to the agent

--- a/internal/multigit/account.go
+++ b/internal/multigit/account.go
@@ -56,7 +56,7 @@ func CreateAccount(accountName, accountEmail, passphrase string, keyType ssh.Key
 	}
 
 	// Create SSH key pair
-	if err := SSHClient.CreateSSHKey(accountName, accountEmail, passphrase, keyType); err != nil {
+	if err := SSHClient.CreateSSHKey(accountName, accountEmail, passphrase, keyType, nil); err != nil {
 		return fmt.Errorf("failed to create SSH key: %w", err)
 	}
 

--- a/internal/multigit/account_test.go
+++ b/internal/multigit/account_test.go
@@ -30,8 +30,8 @@ type MockSSH struct {
 }
 
 // CreateSSHKey mocks the CreateSSHKey function
-func (m *MockSSH) CreateSSHKey(accountName, email, passphrase string, keyType ssh.KeyType) error {
-	args := m.Called(accountName, email, passphrase, keyType)
+func (m *MockSSH) CreateSSHKey(accountName, email, passphrase string, keyType ssh.KeyType, keyFileOverride *string) error {
+	args := m.Called(accountName, email, passphrase, keyType, keyFileOverride)
 	return args.Error(0)
 }
 
@@ -227,7 +227,7 @@ func TestCreateAccount(t *testing.T) {
 				return nil
 			},
 			setupMocks: func(m *MockSSH, accountName, email, passphrase string, keyType ssh.KeyType) {
-				m.On("CreateSSHKey", accountName, email, passphrase, keyType).Return(nil)
+				m.On("CreateSSHKey", accountName, email, passphrase, keyType, (*string)(nil)).Return(nil)
 				m.On("AddSSHKeyToAgent", accountName).Return(nil)
 				m.On("AddSSHConfigEntry", accountName).Return(nil)
 			},
@@ -248,7 +248,7 @@ func TestCreateAccount(t *testing.T) {
 				return nil
 			},
 			setupMocks: func(m *MockSSH, name, email, passphrase string, keyType ssh.KeyType) {
-				m.On("CreateSSHKey", name, email, passphrase, keyType).Return(nil)
+				m.On("CreateSSHKey", name, email, passphrase, keyType, (*string)(nil)).Return(nil)
 				m.On("AddSSHKeyToAgent", name).Return(nil)
 				m.On("AddSSHConfigEntry", name).Return(nil)
 			},
@@ -281,7 +281,7 @@ func TestCreateAccount(t *testing.T) {
 				return errors.New("failed to save config")
 			},
 			setupMocks: func(m *MockSSH, name, email, passphrase string, keyType ssh.KeyType) {
-				m.On("CreateSSHKey", name, email, passphrase, keyType).Return(nil)
+				m.On("CreateSSHKey", name, email, passphrase, keyType, (*string)(nil)).Return(nil)
 				m.On("AddSSHKeyToAgent", name).Return(nil)
 				m.On("AddSSHConfigEntry", name).Return(nil)
 			},
@@ -298,7 +298,7 @@ func TestCreateAccount(t *testing.T) {
 				// No additional setup needed
 			},
 			setupMocks: func(m *MockSSH, name, email, passphrase string, keyType ssh.KeyType) {
-				m.On("CreateSSHKey", name, email, passphrase, keyType).Return(fmt.Errorf("failed to create SSH key"))
+				m.On("CreateSSHKey", name, email, passphrase, keyType, (*string)(nil)).Return(fmt.Errorf("failed to create SSH key"))
 			},
 			expectError: true,
 			errContains: "failed to create SSH key",
@@ -312,7 +312,7 @@ func TestCreateAccount(t *testing.T) {
 				// No additional setup needed
 			},
 			setupMocks: func(m *MockSSH, name, email, passphrase string, keyType ssh.KeyType) {
-				m.On("CreateSSHKey", name, email, passphrase, keyType).Return(nil)
+				m.On("CreateSSHKey", name, email, passphrase, keyType, (*string)(nil)).Return(nil)
 				m.On("AddSSHKeyToAgent", name).Return(fmt.Errorf("failed to add SSH key to agent"))
 			},
 			expectError: true,
@@ -327,7 +327,7 @@ func TestCreateAccount(t *testing.T) {
 				// No additional setup needed
 			},
 			setupMocks: func(m *MockSSH, name, email, passphrase string, keyType ssh.KeyType) {
-				m.On("CreateSSHKey", name, email, passphrase, keyType).Return(nil)
+				m.On("CreateSSHKey", name, email, passphrase, keyType, (*string)(nil)).Return(nil)
 				m.On("AddSSHKeyToAgent", name).Return(nil)
 				m.On("AddSSHConfigEntry", name).Return(fmt.Errorf("failed to add SSH config entry"))
 			},
@@ -344,7 +344,7 @@ func TestCreateAccount(t *testing.T) {
 				testConfig.Accounts = nil
 			},
 			setupMocks: func(m *MockSSH, name, email, passphrase string, keyType ssh.KeyType) {
-				m.On("CreateSSHKey", name, email, passphrase, keyType).Return(nil)
+				m.On("CreateSSHKey", name, email, passphrase, keyType, (*string)(nil)).Return(nil)
 				m.On("AddSSHKeyToAgent", name).Return(nil)
 				m.On("AddSSHConfigEntry", name).Return(nil)
 			},
@@ -588,10 +588,6 @@ func TestGetConfigPath(t *testing.T) {
 	assert.Equal(t, expectedPath, path, "getConfigPath should return the expected path")
 }
 
-
-
-
-
 // TestGetActiveAccount tests the GetActiveAccount function
 func TestGetActiveAccount(t *testing.T) {
 	// Save the original HOME environment variable
@@ -711,7 +707,7 @@ func TestDeleteAccount(t *testing.T) {
 				// Reset mock and set new expectations
 				mockSSH = new(MockSSH)
 				multigit.SSHClient = mockSSH
-				
+
 				// Mock the SSH operations
 				mockSSH.On("DeleteSSHKey", "test-account").Return(nil)
 				mockSSH.On("RemoveSSHConfigEntry", "test-account").Return(nil)
@@ -762,7 +758,7 @@ func TestDeleteAccount(t *testing.T) {
 				// Reset mock and set new expectations
 				mockSSH = new(MockSSH)
 				multigit.SSHClient = mockSSH
-				
+
 				// Mock the SSH operations with an error for DeleteSSHKey
 				mockSSH.On("DeleteSSHKey", "test-account-ssh-error").Return(fmt.Errorf("SSH key deletion error"))
 				mockSSH.On("RemoveSSHConfigEntry", "test-account-ssh-error").Return(nil)
@@ -791,7 +787,7 @@ func TestDeleteAccount(t *testing.T) {
 				// Reset mock and set new expectations
 				mockSSH = new(MockSSH)
 				multigit.SSHClient = mockSSH
-				
+
 				// Mock the SSH operations with an error for RemoveSSHConfigEntry
 				mockSSH.On("DeleteSSHKey", "test-account-config-error").Return(nil)
 				mockSSH.On("RemoveSSHConfigEntry", "test-account-config-error").Return(fmt.Errorf("SSH config removal error"))
@@ -820,7 +816,7 @@ func TestDeleteAccount(t *testing.T) {
 				// Reset mock and set new expectations
 				mockSSH = new(MockSSH)
 				multigit.SSHClient = mockSSH
-				
+
 				// Mock the SSH operations
 				mockSSH.On("DeleteSSHKey", "active-account").Return(nil)
 				mockSSH.On("RemoveSSHConfigEntry", "active-account").Return(nil)
@@ -834,7 +830,7 @@ func TestDeleteAccount(t *testing.T) {
 			// Create a new temp directory for each test case
 			testDir := t.TempDir()
 			os.Setenv("HOME", testDir)
-			
+
 			// Set up the test environment
 			if tt.setup != nil {
 				tt.setup()

--- a/internal/multigit/commands.go
+++ b/internal/multigit/commands.go
@@ -6,13 +6,13 @@ import (
 )
 
 // createSSHKey is a wrapper around ssh.CreateSSHKey
-func createSSHKey(accountName, accountEmail, passphrase string, keyType ssh.KeyType) error {
-	return SSHClient.CreateSSHKey(accountName, accountEmail, passphrase, keyType)
+func createSSHKey(accountName, accountEmail, passphrase string, keyType ssh.KeyType, keyFileOverride *string) error {
+	return SSHClient.CreateSSHKey(accountName, accountEmail, passphrase, keyType, keyFileOverride)
 }
 
 // CreateSSHKeyForTesting exposes createSSHKey for testing
-func CreateSSHKeyForTesting(accountName, accountEmail, passphrase string, keyType ssh.KeyType) error {
-	return createSSHKey(accountName, accountEmail, passphrase, keyType)
+func CreateSSHKeyForTesting(accountName, accountEmail, passphrase string, keyType ssh.KeyType, keyFileOverride *string) error {
+	return createSSHKey(accountName, accountEmail, passphrase, keyType, keyFileOverride)
 }
 
 // addSSHKeyToAgent is a wrapper around ssh.AddSSHKeyToAgent

--- a/internal/multigit/commands_test.go
+++ b/internal/multigit/commands_test.go
@@ -12,7 +12,7 @@ import (
 func TestCreateSSHKey(t *testing.T) {
 	// Create a mock SSH client
 	mockSSH := new(MockSSH)
-	
+
 	// Save the original SSH client and restore it after the test
 	originalSSH := multigit.SSHClient
 	multigit.SSHClient = mockSSH
@@ -27,14 +27,14 @@ func TestCreateSSHKey(t *testing.T) {
 	keyType := ssh.KeyTypeED25519
 
 	// The mock should expect CreateSSHKey to be called with the specified parameters
-	mockSSH.On("CreateSSHKey", accountName, accountEmail, passphrase, keyType).Return(nil)
+	mockSSH.On("CreateSSHKey", accountName, accountEmail, passphrase, keyType, (*string)(nil)).Return(nil)
 
 	// Call the function being tested
-	err := multigit.CreateSSHKeyForTesting(accountName, accountEmail, passphrase, keyType)
-	
+	err := multigit.CreateSSHKeyForTesting(accountName, accountEmail, passphrase, keyType, nil)
+
 	// Verify the error is nil
 	assert.NoError(t, err)
-	
+
 	// Verify that the mock was called as expected
 	mockSSH.AssertExpectations(t)
 }
@@ -43,7 +43,7 @@ func TestCreateSSHKey(t *testing.T) {
 func TestAddSSHKeyToAgent(t *testing.T) {
 	// Create a mock SSH client
 	mockSSH := new(MockSSH)
-	
+
 	// Save the original SSH client and restore it after the test
 	originalSSH := multigit.SSHClient
 	multigit.SSHClient = mockSSH
@@ -59,10 +59,10 @@ func TestAddSSHKeyToAgent(t *testing.T) {
 
 	// Call the function being tested
 	err := multigit.AddSSHKeyToAgentForTesting(accountName)
-	
+
 	// Verify the error is nil
 	assert.NoError(t, err)
-	
+
 	// Verify that the mock was called as expected
 	mockSSH.AssertExpectations(t)
 }
@@ -71,7 +71,7 @@ func TestAddSSHKeyToAgent(t *testing.T) {
 func TestAddSSHConfigEntry(t *testing.T) {
 	// Create a mock SSH client
 	mockSSH := new(MockSSH)
-	
+
 	// Save the original SSH client and restore it after the test
 	originalSSH := multigit.SSHClient
 	multigit.SSHClient = mockSSH
@@ -87,10 +87,10 @@ func TestAddSSHConfigEntry(t *testing.T) {
 
 	// Call the function being tested
 	err := multigit.AddSSHConfigEntryForTesting(accountName)
-	
+
 	// Verify the error is nil
 	assert.NoError(t, err)
-	
+
 	// Verify that the mock was called as expected
 	mockSSH.AssertExpectations(t)
 }
@@ -99,7 +99,7 @@ func TestAddSSHConfigEntry(t *testing.T) {
 func TestCreateSSHKeyError(t *testing.T) {
 	// Create a mock SSH client
 	mockSSH := new(MockSSH)
-	
+
 	// Save the original SSH client and restore it after the test
 	originalSSH := multigit.SSHClient
 	multigit.SSHClient = mockSSH
@@ -115,15 +115,15 @@ func TestCreateSSHKeyError(t *testing.T) {
 
 	// The mock should expect CreateSSHKey to be called and return an error
 	mockError := assert.AnError
-	mockSSH.On("CreateSSHKey", accountName, accountEmail, passphrase, keyType).Return(mockError)
+	mockSSH.On("CreateSSHKey", accountName, accountEmail, passphrase, keyType, (*string)(nil)).Return(mockError)
 
 	// Call the function being tested
-	err := multigit.CreateSSHKeyForTesting(accountName, accountEmail, passphrase, keyType)
-	
+	err := multigit.CreateSSHKeyForTesting(accountName, accountEmail, passphrase, keyType, nil)
+
 	// Verify the error is returned
 	assert.Error(t, err)
 	assert.Equal(t, mockError, err)
-	
+
 	// Verify that the mock was called as expected
 	mockSSH.AssertExpectations(t)
 }
@@ -132,7 +132,7 @@ func TestCreateSSHKeyError(t *testing.T) {
 func TestAddSSHKeyToAgentError(t *testing.T) {
 	// Create a mock SSH client
 	mockSSH := new(MockSSH)
-	
+
 	// Save the original SSH client and restore it after the test
 	originalSSH := multigit.SSHClient
 	multigit.SSHClient = mockSSH
@@ -149,11 +149,11 @@ func TestAddSSHKeyToAgentError(t *testing.T) {
 
 	// Call the function being tested
 	err := multigit.AddSSHKeyToAgentForTesting(accountName)
-	
+
 	// Verify the error is returned
 	assert.Error(t, err)
 	assert.Equal(t, mockError, err)
-	
+
 	// Verify that the mock was called as expected
 	mockSSH.AssertExpectations(t)
 }
@@ -162,7 +162,7 @@ func TestAddSSHKeyToAgentError(t *testing.T) {
 func TestAddSSHConfigEntryError(t *testing.T) {
 	// Create a mock SSH client
 	mockSSH := new(MockSSH)
-	
+
 	// Save the original SSH client and restore it after the test
 	originalSSH := multigit.SSHClient
 	multigit.SSHClient = mockSSH
@@ -179,11 +179,11 @@ func TestAddSSHConfigEntryError(t *testing.T) {
 
 	// Call the function being tested
 	err := multigit.AddSSHConfigEntryForTesting(accountName)
-	
+
 	// Verify the error is returned
 	assert.Error(t, err)
 	assert.Equal(t, mockError, err)
-	
+
 	// Verify that the mock was called as expected
 	mockSSH.AssertExpectations(t)
 }

--- a/internal/multigit/config_test.go
+++ b/internal/multigit/config_test.go
@@ -60,7 +60,7 @@ func TestLoadConfigFromFile(t *testing.T) {
 
 	t.Run("Load non-existent config file", func(t *testing.T) {
 		nonExistentPath := filepath.Join(tempDir, "non_existent.json")
-		
+
 		// Ensure the file doesn't exist
 		_, err := os.Stat(nonExistentPath)
 		require.True(t, os.IsNotExist(err), "Test file should not exist")
@@ -73,7 +73,7 @@ func TestLoadConfigFromFile(t *testing.T) {
 
 	t.Run("Load invalid JSON config file", func(t *testing.T) {
 		invalidConfigPath := filepath.Join(tempDir, "invalid_config.json")
-		
+
 		// Write invalid JSON to the file
 		err := os.WriteFile(invalidConfigPath, []byte("this is not valid JSON"), 0600)
 		require.NoError(t, err, "Failed to write invalid config file")
@@ -92,7 +92,7 @@ func TestSaveConfigToFile(t *testing.T) {
 
 	t.Run("Save config to new file", func(t *testing.T) {
 		configPath := filepath.Join(tempDir, "new_config.json")
-		
+
 		// Create a test config
 		testConfig := multigit.Config{
 			Accounts: map[string]multigit.Account{
@@ -139,7 +139,7 @@ func TestSaveConfigToFile(t *testing.T) {
 
 	t.Run("Save config with invalid active references", func(t *testing.T) {
 		configPath := filepath.Join(tempDir, "invalid_refs_config.json")
-		
+
 		// Create a test config with invalid active references
 		testConfig := multigit.Config{
 			Accounts:      map[string]multigit.Account{},
@@ -169,6 +169,10 @@ func TestSaveConfigToFile(t *testing.T) {
 		// Skip this test on Windows as permissions work differently
 		if os.Getenv("OS") == "Windows_NT" {
 			t.Skip("Skipping permission test on Windows")
+		}
+
+		if os.Geteuid() == 0 {
+			t.Skip("Skipping permission test when running as root")
 		}
 
 		// Create a directory with no write permission

--- a/internal/ssh/bcryptpbkdf.go
+++ b/internal/ssh/bcryptpbkdf.go
@@ -1,0 +1,83 @@
+package ssh
+
+import (
+	"crypto/sha512"
+	"errors"
+
+	"golang.org/x/crypto/blowfish"
+)
+
+const bcryptPBKDFBlockSize = 32
+
+func bcryptPBKDF(password, salt []byte, rounds, keyLen int) ([]byte, error) {
+	if rounds < 1 {
+		return nil, errors.New("bcrypt_pbkdf: number of rounds is too small")
+	}
+	if len(password) == 0 {
+		return nil, errors.New("bcrypt_pbkdf: empty password")
+	}
+	if len(salt) == 0 || len(salt) > 1<<20 {
+		return nil, errors.New("bcrypt_pbkdf: bad salt length")
+	}
+	if keyLen > 1024 {
+		return nil, errors.New("bcrypt_pbkdf: keyLen is too large")
+	}
+
+	numBlocks := (keyLen + bcryptPBKDFBlockSize - 1) / bcryptPBKDFBlockSize
+	key := make([]byte, numBlocks*bcryptPBKDFBlockSize)
+
+	h := sha512.New()
+	h.Write(password)
+	shapass := h.Sum(nil)
+
+	shasalt := make([]byte, 0, sha512.Size)
+	cnt, tmp := make([]byte, 4), make([]byte, bcryptPBKDFBlockSize)
+	for block := 1; block <= numBlocks; block++ {
+		h.Reset()
+		h.Write(salt)
+		cnt[0] = byte(block >> 24)
+		cnt[1] = byte(block >> 16)
+		cnt[2] = byte(block >> 8)
+		cnt[3] = byte(block)
+		h.Write(cnt)
+		bcryptHash(tmp, shapass, h.Sum(shasalt))
+
+		out := make([]byte, bcryptPBKDFBlockSize)
+		copy(out, tmp)
+		for i := 2; i <= rounds; i++ {
+			h.Reset()
+			h.Write(tmp)
+			bcryptHash(tmp, shapass, h.Sum(shasalt))
+			for j := 0; j < len(out); j++ {
+				out[j] ^= tmp[j]
+			}
+		}
+
+		for i, v := range out {
+			key[i*numBlocks+(block-1)] = v
+		}
+	}
+	return key[:keyLen], nil
+}
+
+var bcryptMagic = []byte("OxychromaticBlowfishSwatDynamite")
+
+func bcryptHash(out, shapass, shasalt []byte) {
+	c, err := blowfish.NewSaltedCipher(shapass, shasalt)
+	if err != nil {
+		panic(err)
+	}
+	for i := 0; i < 64; i++ {
+		blowfish.ExpandKey(shasalt, c)
+		blowfish.ExpandKey(shapass, c)
+	}
+	copy(out, bcryptMagic)
+	for i := 0; i < 32; i += 8 {
+		for j := 0; j < 64; j++ {
+			c.Encrypt(out[i:i+8], out[i:i+8])
+		}
+	}
+	for i := 0; i < 32; i += 4 {
+		out[i+3], out[i+2], out[i+1], out[i] = out[i], out[i+1], out[i+2], out[i+3]
+	}
+}

--- a/internal/ssh/mock_ssh.go
+++ b/internal/ssh/mock_ssh.go
@@ -8,8 +8,8 @@ type MockSSH struct {
 }
 
 // CreateSSHKey mocks the CreateSSHKey function
-func (m *MockSSH) CreateSSHKey(accountName, email, passphrase string, keyType KeyType) error {
-	args := m.Called(accountName, email, passphrase, keyType)
+func (m *MockSSH) CreateSSHKey(accountName, email, passphrase string, keyType KeyType, keyFileOverride *string) error {
+	args := m.Called(accountName, email, passphrase, keyType, keyFileOverride)
 	return args.Error(0)
 }
 

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -1,11 +1,14 @@
 package ssh
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/pem"
 	"fmt"
 	"log"
@@ -27,84 +30,134 @@ type CommandRunner func(name string, arg ...string) *exec.Cmd
 var ExecCommand CommandRunner = exec.Command
 
 const (
-	rsaKeyBitSize = 4096
+	rsaKeyBitSize     = 4096
+	openSSHKeyV1Magic = "openssh-key-v1\x00"
 	// ED25519 keys are always 256 bits (32 bytes) when using the standard implementation
 )
 
-// MarshalED25519PrivateKey converts an ED25519 private key to OpenSSH format
-func MarshalED25519PrivateKey(key ed25519.PrivateKey, comment string) []byte {
-	// The public key is the last 32 bytes of the private key
+// MarshalED25519PrivateKey converts an ED25519 private key to OpenSSH format.
+// When a non-empty passphrase is provided, the resulting key is encrypted using
+// bcrypt_pbkdf with AES-256-CTR, matching OpenSSH's native format.
+func MarshalED25519PrivateKey(key ed25519.PrivateKey, comment, passphrase string) ([]byte, error) {
 	publicKey := key.Public().(ed25519.PublicKey)
-
-	// The private key is the seed (first 32 bytes of the private key)
 	seed := key.Seed()
 
-	// Create the key data in OpenSSH format
-	keyData := struct {
-		CipherName   string
-		KdfName      string
-		KdfOpts      string
-		NumKeys      uint32
-		PubKey       []byte
-		PrivKeyBlock []byte
-	}{
-		CipherName: "none",
-		KdfName:    "none",
-		KdfOpts:    "",
-		NumKeys:    1,
+	checkBytes := make([]byte, 4)
+	if _, err := rand.Read(checkBytes); err != nil {
+		return nil, fmt.Errorf("failed to generate check bytes: %w", err)
 	}
+	checkValue := binary.BigEndian.Uint32(checkBytes)
 
-	// Public key
-	pubKeyData := struct {
-		KeyType string
-		Key     []byte
-	}{
-		KeyType: "ssh-ed25519",
-		Key:     publicKey,
-	}
-	keyData.PubKey = ssh.Marshal(pubKeyData)
-
-	// Private key block
-	privKeyData := struct {
-		Check1  uint64
-		Check2  uint64
+	privKeyStruct := struct {
+		Check1  uint32
+		Check2  uint32
 		KeyType string
 		PubKey  []byte
 		PrivKey []byte
 		Comment string
-		Pad     []byte `ssh:"rest"`
 	}{
-		Check1:  0, // checkint1
-		Check2:  0, // checkint2 (same as checkint1)
-		KeyType: "ssh-ed25519",
+		Check1:  checkValue,
+		Check2:  checkValue,
+		KeyType: ssh.KeyAlgoED25519,
 		PubKey:  publicKey,
-		PrivKey: append(seed, publicKey...), // seed + public key
+		PrivKey: append(seed, publicKey...),
 		Comment: comment,
 	}
 
-	// Marshal the private key data
-	keyData.PrivKeyBlock = ssh.Marshal(privKeyData)
+	privKeyBlock := ssh.Marshal(privKeyStruct)
+	blockSize := 8
+	if passphrase != "" {
+		blockSize = aes.BlockSize
+	}
+	privKeyBlock = generateOpenSSHPadding(privKeyBlock, blockSize)
 
-	// Add padding to make the private key length a multiple of the cipher block size (8 bytes)
-	if pad := len(keyData.PrivKeyBlock) % 8; pad != 0 {
-		padding := make([]byte, 8-pad)
-		for i := range padding {
-			padding[i] = byte(i + 1)
+	pubKeyData := struct {
+		KeyType string
+		Key     []byte
+	}{
+		KeyType: ssh.KeyAlgoED25519,
+		Key:     publicKey,
+	}
+	pubKeyBlock := ssh.Marshal(pubKeyData)
+
+	cipherName := "none"
+	kdfName := "none"
+	var kdfOpts []byte
+	if passphrase != "" {
+		encrypted, cipher, kdf, opts, err := encryptOpenSSHPrivateKey(privKeyBlock, passphrase)
+		if err != nil {
+			return nil, err
 		}
-		keyData.PrivKeyBlock = append(keyData.PrivKeyBlock, padding...)
+		privKeyBlock = encrypted
+		cipherName = cipher
+		kdfName = kdf
+		kdfOpts = opts
 	}
 
-	// Create the OpenSSH private key format
-	magic := append([]byte("openssh-key-v1\x00"), 0)
-	data := ssh.Marshal(keyData)
+	keyData := struct {
+		CipherName   string
+		KdfName      string
+		KdfOpts      []byte `ssh:"string"`
+		NumKeys      uint32
+		PubKey       []byte `ssh:"string"`
+		PrivKeyBlock []byte `ssh:"string"`
+	}{
+		CipherName:   cipherName,
+		KdfName:      kdfName,
+		KdfOpts:      kdfOpts,
+		NumKeys:      1,
+		PubKey:       pubKeyBlock,
+		PrivKeyBlock: privKeyBlock,
+	}
 
-	// Create the PEM block
+	encoded := append([]byte(openSSHKeyV1Magic), ssh.Marshal(keyData)...)
 	pemBlock := &pem.Block{
 		Type:  "OPENSSH PRIVATE KEY",
-		Bytes: append(magic, data...),
+		Bytes: encoded,
 	}
 
-	return pem.EncodeToMemory(pemBlock)
+	return pem.EncodeToMemory(pemBlock), nil
+}
+
+func generateOpenSSHPadding(block []byte, blockSize int) []byte {
+	if blockSize <= 0 {
+		return block
+	}
+
+	for i, l := 0, len(block); (l+i)%blockSize != 0; i++ {
+		block = append(block, byte(i+1))
+	}
+
+	return block
+}
+
+func encryptOpenSSHPrivateKey(privKeyBlock []byte, passphrase string) ([]byte, string, string, []byte, error) {
+	salt := make([]byte, 16)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, "", "", nil, fmt.Errorf("failed to generate salt: %w", err)
+	}
+
+	const rounds = 16
+	key, err := bcryptPBKDF([]byte(passphrase), salt, rounds, 32+aes.BlockSize)
+	if err != nil {
+		return nil, "", "", nil, fmt.Errorf("failed to derive encryption key: %w", err)
+	}
+
+	dst := make([]byte, len(privKeyBlock))
+	cipherBlock, err := aes.NewCipher(key[:32])
+	if err != nil {
+		return nil, "", "", nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	stream := cipher.NewCTR(cipherBlock, key[32:])
+	stream.XORKeyStream(dst, privKeyBlock)
+
+	kdfOpts := ssh.Marshal(&struct {
+		Salt   []byte
+		Rounds uint32
+	}{Salt: salt, Rounds: rounds})
+
+	return dst, "aes256-ctr", "bcrypt", kdfOpts, nil
 }
 
 // ValidatePrivateKey attempts to parse the private key to ensure it's in a valid format
@@ -137,37 +190,39 @@ func ValidatePrivateKey(keyData []byte) error {
 	}
 }
 
-// CreateSSHKey creates a new SSH key pair for the given account
-func CreateSSHKey(accountName, accountEmail, keyFile string, keyType KeyType) error {
+// CreateSSHKey creates a new SSH key pair for the given account.
+// When keyFileOverride is nil or empty, the key is written to the default
+// location of ~/.ssh/id_<type>_<account>.
+func CreateSSHKey(accountName, accountEmail, passphrase string, keyType KeyType, keyFileOverride *string) error {
 	if keyType == "" {
 		keyType = KeyTypeED25519 // Default to ED25519
 	}
 
-	// If keyFile is not provided, use default location in .ssh directory
-	if keyFile == "" {
+	var keyFile string
+	if keyFileOverride != nil && *keyFileOverride != "" {
+		keyFile = *keyFileOverride
+		parentDir := filepath.Dir(keyFile)
+		if err := os.MkdirAll(parentDir, 0700); err != nil {
+			return fmt.Errorf("failed to create directory for key file: %w", err)
+		}
+	} else {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return fmt.Errorf("failed to get home directory: %w", err)
 		}
 
-		// Create .ssh directory if it doesn't exist
 		sshDir := filepath.Join(homeDir, ".ssh")
 		if err := os.MkdirAll(sshDir, 0700); err != nil {
 			return fmt.Errorf("failed to create .ssh directory: %w", err)
 		}
 
-		// Generate default key file path based on key type
 		switch keyType {
 		case KeyTypeRSA:
 			keyFile = filepath.Join(sshDir, fmt.Sprintf("id_rsa_%s", accountName))
 		case KeyTypeED25519:
 			keyFile = filepath.Join(sshDir, fmt.Sprintf("id_ed25519_%s", accountName))
-		}
-	} else {
-		// Ensure parent directory exists
-		parentDir := filepath.Dir(keyFile)
-		if err := os.MkdirAll(parentDir, 0700); err != nil {
-			return fmt.Errorf("failed to create directory for key file: %w", err)
+		default:
+			return fmt.Errorf("unsupported key type: %s", keyType)
 		}
 	}
 
@@ -183,9 +238,19 @@ func CreateSSHKey(accountName, accountEmail, keyFile string, keyType KeyType) er
 		}
 
 		// Create private key in PKCS#1 format
-		privateKeyPEM := &pem.Block{
-			Type:  "RSA PRIVATE KEY",
-			Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+		privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+		var privateKeyPEM *pem.Block
+		if passphrase != "" {
+			encryptedBlock, err := x509.EncryptPEMBlock(rand.Reader, "RSA PRIVATE KEY", privateKeyBytes, []byte(passphrase), x509.PEMCipherAES256)
+			if err != nil {
+				return fmt.Errorf("failed to encrypt RSA private key: %w", err)
+			}
+			privateKeyPEM = encryptedBlock
+		} else {
+			privateKeyPEM = &pem.Block{
+				Type:  "RSA PRIVATE KEY",
+				Bytes: privateKeyBytes,
+			}
 		}
 
 		// Write private key to file
@@ -213,7 +278,10 @@ func CreateSSHKey(accountName, accountEmail, keyFile string, keyType KeyType) er
 		}
 
 		// Marshal private key in OpenSSH format
-		privateKeyBytes := MarshalED25519PrivateKey(privKey, comment)
+		privateKeyBytes, err := MarshalED25519PrivateKey(privKey, comment, passphrase)
+		if err != nil {
+			return fmt.Errorf("failed to marshal ED25519 private key: %w", err)
+		}
 
 		// Validate the private key
 		if err := ValidatePrivateKey(privateKeyBytes); err != nil {

--- a/internal/ssh/ssh_benchmark_test.go
+++ b/internal/ssh/ssh_benchmark_test.go
@@ -19,7 +19,7 @@ func BenchmarkCreateSSHKey(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		keyFile := filepath.Join(tempDir, "test_key")
-		err := ssh.CreateSSHKey("benchmark", "benchmark@example.com", keyFile, ssh.KeyTypeRSA)
+		err := ssh.CreateSSHKey("benchmark", "benchmark@example.com", "", ssh.KeyTypeRSA, &keyFile)
 		if err != nil {
 			b.Fatalf("Failed to create SSH key: %v", err)
 		}
@@ -34,7 +34,7 @@ func BenchmarkAddSSHKeyToAgent(b *testing.B) {
 	defer os.RemoveAll(tempDir)
 
 	keyFile := filepath.Join(tempDir, "test_key")
-	err = ssh.CreateSSHKey("benchmark", "benchmark@example.com", keyFile, ssh.KeyTypeRSA)
+	err = ssh.CreateSSHKey("benchmark", "benchmark@example.com", "", ssh.KeyTypeRSA, &keyFile)
 	if err != nil {
 		b.Fatalf("Failed to create SSH key: %v", err)
 	}

--- a/internal/ssh/ssh_interface.go
+++ b/internal/ssh/ssh_interface.go
@@ -12,7 +12,7 @@ const (
 
 // SSHOperations defines the interface for SSH-related operations
 type SSHOperations interface {
-	CreateSSHKey(accountName, email, passphrase string, keyType KeyType) error
+	CreateSSHKey(accountName, email, passphrase string, keyType KeyType, keyFileOverride *string) error
 	// AddSSHKeyToAgent adds an SSH key to the agent. If keyFile is provided, it will be used directly.
 	// Otherwise, it will look for the key in ~/.ssh/id_ed25519_{accountName}
 	AddSSHKeyToAgent(accountOrKeyFile string) error
@@ -25,8 +25,8 @@ type SSHOperations interface {
 type DefaultSSH struct{}
 
 // CreateSSHKey creates a new SSH key pair
-func (d *DefaultSSH) CreateSSHKey(accountName, email, passphrase string, keyType KeyType) error {
-	return CreateSSHKey(accountName, email, passphrase, keyType)
+func (d *DefaultSSH) CreateSSHKey(accountName, email, passphrase string, keyType KeyType, keyFileOverride *string) error {
+	return CreateSSHKey(accountName, email, passphrase, keyType, keyFileOverride)
 }
 
 // AddSSHKeyToAgent adds the SSH key to the SSH agent

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -3,6 +3,7 @@ package ssh_test
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,6 +14,7 @@ import (
 	"github.com/cpuix/multigit/internal/ssh"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
 )
 
 // Test için gerekli wrapper fonksiyonlar
@@ -21,8 +23,8 @@ var (
 		return ssh.SSHPublicKeyED25519(pubKey, comment)
 	}
 
-	marshalED25519PrivateKey = func(key ed25519.PrivateKey, comment string) []byte {
-		return ssh.MarshalED25519PrivateKey(key, comment)
+	marshalED25519PrivateKey = func(key ed25519.PrivateKey, comment, passphrase string) ([]byte, error) {
+		return ssh.MarshalED25519PrivateKey(key, comment, passphrase)
 	}
 
 	validatePrivateKey = func(keyData []byte) error {
@@ -81,7 +83,7 @@ func TestCreateAndDeleteSSHKey(t *testing.T) {
 
 	// Test key creation
 	t.Run("CreateSSHKey", func(t *testing.T) {
-		err := ssh.CreateSSHKey(accountName, accountEmail, keyFile, ssh.KeyTypeED25519)
+		err := ssh.CreateSSHKey(accountName, accountEmail, "", ssh.KeyTypeED25519, nil)
 		require.NoError(t, err, "Failed to create SSH key")
 
 		// Check if key files were created (ED25519 keys)
@@ -92,6 +94,12 @@ func TestCreateAndDeleteSSHKey(t *testing.T) {
 
 		_, err = os.Stat(publicKeyPath)
 		assert.NoError(t, err, "Public key file should exist")
+
+		privateKeyBytes, err := os.ReadFile(keyFile)
+		require.NoError(t, err, "Failed to read generated private key")
+
+		_, err = gossh.ParseRawPrivateKey(privateKeyBytes)
+		require.NoError(t, err, "Expected unprotected key to be parseable without passphrase")
 	})
 
 	// Test key deletion
@@ -108,6 +116,36 @@ func TestCreateAndDeleteSSHKey(t *testing.T) {
 		_, err = os.Stat(publicKeyPath)
 		assert.True(t, os.IsNotExist(err), "Public key file should not exist")
 	})
+}
+
+func TestCreateSSHKeyWithPassphrase(t *testing.T) {
+	tempDir := t.TempDir()
+
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", oldHome)
+
+	accountName := "secure-account"
+	accountEmail := "secure@example.com"
+	passphrase := "super-secret"
+
+	err := ssh.CreateSSHKey(accountName, accountEmail, passphrase, ssh.KeyTypeED25519, nil)
+	require.NoError(t, err, "Failed to create passphrase protected key")
+
+	keyFile := filepath.Join(tempDir, ".ssh", fmt.Sprintf("id_ed25519_%s", accountName))
+	require.FileExists(t, keyFile, "Protected private key should exist at default location")
+	require.FileExists(t, keyFile+".pub", "Protected public key should exist at default location")
+
+	keyBytes, err := os.ReadFile(keyFile)
+	require.NoError(t, err, "Failed to read protected key")
+
+	_, err = gossh.ParseRawPrivateKey(keyBytes)
+	var missingErr *gossh.PassphraseMissingError
+	assert.Error(t, err, "Expected parsing to fail without passphrase")
+	assert.True(t, errors.As(err, &missingErr), "Expected passphrase missing error")
+
+	_, err = gossh.ParseRawPrivateKeyWithPassphrase(keyBytes, []byte(passphrase))
+	require.NoError(t, err, "Expected parsing to succeed with passphrase")
 }
 
 func setupTestSSHConfig(t *testing.T) (string, string) {
@@ -179,7 +217,7 @@ func TestCreateSSHKey(t *testing.T) {
 			os.Setenv("HOME", tempDir)
 			defer os.Setenv("HOME", oldHome)
 
-			err := ssh.CreateSSHKey("test-account", "test@example.com", keyFile, ssh.KeyType(tt.keyType))
+			err := ssh.CreateSSHKey("test-account", "test@example.com", "", ssh.KeyType(tt.keyType), &keyFile)
 
 			if tt.expectError {
 				require.Error(t, err, "Expected error but got none")
@@ -226,7 +264,7 @@ func TestDeleteSSHKey(t *testing.T) {
 			name: "Delete existing RSA key by account name",
 			setup: func(t *testing.T, tempDir string) (string, []string) {
 				keyFile := filepath.Join(tempDir, "id_rsa_test-account")
-				err := ssh.CreateSSHKey("test-account", "test@example.com", keyFile, ssh.KeyTypeRSA)
+				err := ssh.CreateSSHKey("test-account", "test@example.com", "", ssh.KeyTypeRSA, &keyFile)
 				require.NoError(t, err, "Failed to create test key")
 				return "test-account", []string{
 					keyFile,
@@ -241,7 +279,7 @@ func TestDeleteSSHKey(t *testing.T) {
 			name: "Delete existing ED25519 key by account name",
 			setup: func(t *testing.T, tempDir string) (string, []string) {
 				keyFile := filepath.Join(tempDir, "id_ed25519_test-account-ed25519")
-				err := ssh.CreateSSHKey("test-account-ed25519", "test@example.com", keyFile, ssh.KeyTypeED25519)
+				err := ssh.CreateSSHKey("test-account-ed25519", "test@example.com", "", ssh.KeyTypeED25519, &keyFile)
 				require.NoError(t, err, "Failed to create test key")
 				return "test-account-ed25519", []string{
 					keyFile,
@@ -264,7 +302,7 @@ func TestDeleteSSHKey(t *testing.T) {
 			name: "Delete existing key by file path",
 			setup: func(t *testing.T, tempDir string) (string, []string) {
 				keyFile := filepath.Join(tempDir, "id_rsa_test_file")
-				err := ssh.CreateSSHKey("test-account-file", "test@example.com", keyFile, ssh.KeyTypeRSA)
+				err := ssh.CreateSSHKey("test-account-file", "test@example.com", "", ssh.KeyTypeRSA, &keyFile)
 				require.NoError(t, err, "Failed to create test key")
 				return keyFile, []string{
 					keyFile,
@@ -293,10 +331,10 @@ func TestDeleteSSHKey(t *testing.T) {
 				rsaKeyFile := filepath.Join(tempDir, "id_rsa_multi-account")
 				ed25519KeyFile := filepath.Join(tempDir, "id_ed25519_multi-account")
 
-				err := ssh.CreateSSHKey("multi-account", "test@example.com", rsaKeyFile, ssh.KeyTypeRSA)
+				err := ssh.CreateSSHKey("multi-account", "test@example.com", "", ssh.KeyTypeRSA, &rsaKeyFile)
 				require.NoError(t, err, "Failed to create RSA test key")
 
-				err = ssh.CreateSSHKey("multi-account", "test@example.com", ed25519KeyFile, ssh.KeyTypeED25519)
+				err = ssh.CreateSSHKey("multi-account", "test@example.com", "", ssh.KeyTypeED25519, &ed25519KeyFile)
 				require.NoError(t, err, "Failed to create ED25519 test key")
 
 				return "multi-account", []string{
@@ -314,7 +352,7 @@ func TestDeleteSSHKey(t *testing.T) {
 			name: "Fail when cannot delete private key",
 			setup: func(t *testing.T, tempDir string) (string, []string) {
 				keyFile := filepath.Join(tempDir, "id_rsa_protected")
-				err := ssh.CreateSSHKey("protected-account", "test@example.com", keyFile, ssh.KeyTypeRSA)
+				err := ssh.CreateSSHKey("protected-account", "test@example.com", "", ssh.KeyTypeRSA, &keyFile)
 				require.NoError(t, err, "Failed to create test key")
 
 				// Make the directory read-only to prevent file deletion
@@ -346,6 +384,10 @@ func TestDeleteSSHKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if os.Geteuid() == 0 && tt.expectError && (strings.Contains(tt.name, "cannot delete private key") || tt.name == "Error checking private key file") {
+				t.Skip("Skipping permission denied test when running as root")
+			}
+
 			tempDir := t.TempDir()
 
 			// Override home directory for this test
@@ -444,7 +486,10 @@ func TestSSHConfigManagement(t *testing.T) {
 				}
 
 				// Write private key
-				privateKeyBytes := ssh.MarshalED25519PrivateKey(privKey, "test@example.com")
+				privateKeyBytes, err := ssh.MarshalED25519PrivateKey(privKey, "test@example.com", "")
+				if err != nil {
+					return fmt.Errorf("failed to marshal ED25519 private key: %w", err)
+				}
 				if err := os.WriteFile(keyFile, privateKeyBytes, 0600); err != nil {
 					return fmt.Errorf("failed to write private key: %w", err)
 				}
@@ -505,7 +550,10 @@ func TestSSHConfigManagement(t *testing.T) {
 				}
 
 				// Write private key
-				privateKeyBytes := ssh.MarshalED25519PrivateKey(privKey, "test@example.com")
+				privateKeyBytes, err := ssh.MarshalED25519PrivateKey(privKey, "test@example.com", "")
+				if err != nil {
+					return fmt.Errorf("failed to marshal ED25519 private key: %w", err)
+				}
 				if err := os.WriteFile(keyFile, privateKeyBytes, 0600); err != nil {
 					return fmt.Errorf("failed to write private key: %w", err)
 				}
@@ -613,7 +661,7 @@ func TestDeleteSSHKeyFile(t *testing.T) {
 			name: "Delete existing key file",
 			setup: func(t *testing.T, tempDir string) (string, []string) {
 				keyFile := filepath.Join(tempDir, "id_rsa_test")
-				err := ssh.CreateSSHKey("test-account", "test@example.com", keyFile, ssh.KeyTypeRSA)
+				err := ssh.CreateSSHKey("test-account", "test@example.com", "", ssh.KeyTypeRSA, &keyFile)
 				require.NoError(t, err, "Failed to create test key")
 				return keyFile, []string{
 					keyFile,
@@ -641,11 +689,11 @@ func TestDeleteSSHKeyFile(t *testing.T) {
 				// Create only a public key file
 				keyFile := filepath.Join(tempDir, "id_rsa_public_only")
 				pubKeyFile := keyFile + ".pub"
-				
+
 				// Create a dummy public key file
 				err := os.WriteFile(pubKeyFile, []byte("ssh-rsa AAAAB3NzaC1yc2E test@example.com"), 0644)
 				require.NoError(t, err, "Failed to create test public key")
-				
+
 				return keyFile, []string{
 					pubKeyFile,
 				}
@@ -660,16 +708,16 @@ func TestDeleteSSHKeyFile(t *testing.T) {
 				keyDir := filepath.Join(tempDir, "key_dir")
 				err := os.MkdirAll(keyDir, 0700)
 				require.NoError(t, err, "Failed to create directory")
-				
+
 				// Make it inaccessible to cause a stat error
 				err = os.Chmod(keyDir, 0000) // No permissions
 				require.NoError(t, err, "Failed to set directory permissions")
-				
+
 				t.Cleanup(func() {
 					// Restore permissions for cleanup
 					os.Chmod(keyDir, 0700)
 				})
-				
+
 				keyFile := filepath.Join(keyDir, "id_rsa")
 				return keyFile, []string{}
 			},
@@ -683,18 +731,18 @@ func TestDeleteSSHKeyFile(t *testing.T) {
 				keyFile := filepath.Join(tempDir, "id_rsa_error")
 				err := os.WriteFile(keyFile, []byte("dummy private key"), 0600)
 				require.NoError(t, err, "Failed to create test key")
-				
+
 				// Create a directory with the same name as the public key file
 				pubKeyDir := keyFile + ".pub"
 				err = os.MkdirAll(pubKeyDir, 0700)
 				require.NoError(t, err, "Failed to create directory")
-				
+
 				// Create a file inside the directory to ensure os.Remove fails
 				// (can't remove non-empty directory)
 				dummyFile := filepath.Join(pubKeyDir, "dummy")
 				err = os.WriteFile(dummyFile, []byte("dummy"), 0600)
 				require.NoError(t, err, "Failed to create dummy file")
-				
+
 				return keyFile, []string{
 					keyFile,
 					pubKeyDir,
@@ -707,7 +755,7 @@ func TestDeleteSSHKeyFile(t *testing.T) {
 			name: "Fail when cannot delete private key",
 			setup: func(t *testing.T, tempDir string) (string, []string) {
 				keyFile := filepath.Join(tempDir, "id_rsa_protected")
-				err := ssh.CreateSSHKey("protected-account", "test@example.com", keyFile, ssh.KeyTypeRSA)
+				err := ssh.CreateSSHKey("protected-account", "test@example.com", "", ssh.KeyTypeRSA, &keyFile)
 				require.NoError(t, err, "Failed to create test key")
 
 				// Make the directory read-only to prevent file deletion
@@ -735,6 +783,10 @@ func TestDeleteSSHKeyFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if os.Geteuid() == 0 && tt.expectError && (strings.Contains(tt.name, "cannot delete private key") || tt.name == "Error checking private key file") {
+				t.Skip("Skipping permission denied test when running as root")
+			}
+
 			tempDir := t.TempDir()
 
 			// Setup test case
@@ -814,7 +866,8 @@ func TestMarshalED25519PrivateKey(t *testing.T) {
 	comment := "test@example.com"
 
 	t.Run("ValidKey", func(t *testing.T) {
-		keyData := marshalED25519PrivateKey(privKey, comment)
+		keyData, err := marshalED25519PrivateKey(privKey, comment, "")
+		require.NoError(t, err, "Expected marshaling without passphrase to succeed")
 		assert.NotEmpty(t, keyData, "Marshaled key should not be empty")
 		assert.Contains(t, string(keyData), "PRIVATE KEY", "Should contain PRIVATE KEY header")
 	})
@@ -822,7 +875,7 @@ func TestMarshalED25519PrivateKey(t *testing.T) {
 	t.Run("NilKey", func(t *testing.T) {
 		// This should panic with nil key, so we'll recover from the panic
 		assert.Panics(t, func() {
-			_ = marshalED25519PrivateKey(nil, comment)
+			_, _ = marshalED25519PrivateKey(nil, comment, "")
 		}, "Should panic with nil key")
 	})
 }
@@ -833,8 +886,9 @@ func TestValidatePrivateKey(t *testing.T) {
 	require.NoError(t, err, "Failed to generate ED25519 key pair")
 
 	t.Run("ValidKey", func(t *testing.T) {
-		keyData := marshalED25519PrivateKey(privKey, "test@example.com")
-		err := validatePrivateKey(keyData)
+		keyData, err := marshalED25519PrivateKey(privKey, "test@example.com", "")
+		require.NoError(t, err, "Expected marshaling without passphrase to succeed")
+		err = validatePrivateKey(keyData)
 		assert.NoError(t, err, "Valid key should pass validation")
 	})
 
@@ -885,7 +939,8 @@ func TestAddSSHKeyToAgent(t *testing.T) {
 				// Create a test private key file directly
 				_, privKey, err := ed25519.GenerateKey(rand.Reader)
 				require.NoError(t, err, "Failed to generate test key")
-				keyData := ssh.MarshalED25519PrivateKey(privKey, "test@example.com")
+				keyData, err := ssh.MarshalED25519PrivateKey(privKey, "test@example.com", "")
+				require.NoError(t, err, "Failed to marshal test key")
 				require.NoError(t, os.WriteFile(keyFile, keyData, 0600), "Failed to write test key")
 
 				// Mock successful ssh-add command
@@ -912,7 +967,8 @@ func TestAddSSHKeyToAgent(t *testing.T) {
 				// Create a test private key file directly
 				_, privKey, err := ed25519.GenerateKey(rand.Reader)
 				require.NoError(t, err, "Failed to generate test key")
-				keyData := ssh.MarshalED25519PrivateKey(privKey, "test@example.com")
+				keyData, err := ssh.MarshalED25519PrivateKey(privKey, "test@example.com", "")
+				require.NoError(t, err, "Failed to marshal test key")
 				require.NoError(t, os.WriteFile(keyFile, keyData, 0600), "Failed to write test key")
 
 				// Unset SSH_AUTH_SOCK to simulate agent not running
@@ -926,7 +982,8 @@ func TestAddSSHKeyToAgent(t *testing.T) {
 				// Create a test private key file directly
 				_, privKey, err := ed25519.GenerateKey(rand.Reader)
 				require.NoError(t, err, "Failed to generate test key")
-				keyData := ssh.MarshalED25519PrivateKey(privKey, "test@example.com")
+				keyData, err := ssh.MarshalED25519PrivateKey(privKey, "test@example.com", "")
+				require.NoError(t, err, "Failed to marshal test key")
 				require.NoError(t, os.WriteFile(keyFile, keyData, 0600), "Failed to write test key")
 
 				// Mock failing ssh-add command
@@ -943,7 +1000,7 @@ func TestAddSSHKeyToAgent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Reset SSH_AUTH_SOCK to default for each test case
 			os.Setenv("SSH_AUTH_SOCK", "/tmp/ssh-agent.sock")
-			
+
 			// Setup test case
 			tc.setup()
 


### PR DESCRIPTION
## Summary
- ensure CreateSSHKey derives default ~/.ssh paths and encrypts private keys when a passphrase is supplied
- add bcrypt_pbkdf helper plus supporting utilities to emit encrypted OpenSSH ed25519 keys
- update commands, interfaces, mocks, and tests to pass the new signature and cover passphrase-protected key scenarios
- fix delete command force flag wiring and stabilize integration and SSH deletion tests under root

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cbe26632d4832aaa434ef75743b8fa