### PR TITLE
Support ED25519 keys in list and status commands

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -48,11 +48,12 @@ var listCmd = &cobra.Command{
 
 			// Show SSH key info if available
 			homeDir, _ := os.UserHomeDir()
-			keyPath := fmt.Sprintf("%s/.ssh/id_rsa_%s", homeDir, name)
-			if _, err := os.Stat(keyPath); err == nil {
+			keyPath, found, candidates := resolveSSHKeyPath(homeDir, name)
+			if found {
 				fmt.Printf("  SSH Key: %s\n", keyPath)
 			} else {
-				fmt.Printf("  SSH Key: %s (not found)\n", color.YellowString(keyPath))
+				fmt.Printf("  SSH Key: %s (not found)\n",
+					color.YellowString(fmt.Sprintf("%s or %s", candidates[0], candidates[1])))
 			}
 
 			// Show active status

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -72,6 +72,15 @@ func TestListCommand(t *testing.T) {
 		os.Stdout = w
 		defer func() { os.Stdout = oldStdout }()
 
+		// Prepare SSH directory with an ED25519 key for the active account
+		sshDir := filepath.Join(tempDir, ".ssh")
+		err = os.MkdirAll(sshDir, 0700)
+		require.NoError(t, err, "Failed to create SSH directory")
+
+		edKeyPath := filepath.Join(sshDir, "id_ed25519_test-account")
+		err = os.WriteFile(edKeyPath, []byte("dummy"), 0600)
+		require.NoError(t, err, "Failed to create ED25519 key file")
+
 		// Create a config with accounts
 		config := multigit.NewConfig()
 		config.Accounts = map[string]multigit.Account{
@@ -108,5 +117,11 @@ func TestListCommand(t *testing.T) {
 		assert.Contains(t, output, "test@example.com", "Output should contain the test account email")
 		assert.Contains(t, output, "another@example.com", "Output should contain the another account email")
 		assert.Contains(t, output, "Active account", "Output should indicate which account is active")
+		assert.Contains(t, output, edKeyPath, "Output should report the ED25519 SSH key path")
+
+		rsaMissingPath := filepath.Join(sshDir, "id_rsa_another-account")
+		edMissingPath := filepath.Join(sshDir, "id_ed25519_another-account")
+		assert.Contains(t, output, rsaMissingPath+" or "+edMissingPath,
+			"Output should mention both possible key paths when no key is found")
 	})
 }

--- a/cmd/ssh_keys.go
+++ b/cmd/ssh_keys.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// resolveSSHKeyPath searches for SSH keys associated with an account.
+// It returns the first existing key path (preferring RSA, then ED25519),
+// a boolean indicating whether a key was found, and the list of candidate
+// paths that were checked.
+func resolveSSHKeyPath(homeDir, accountName string) (string, bool, []string) {
+	candidates := []string{
+		filepath.Join(homeDir, ".ssh", fmt.Sprintf("id_rsa_%s", accountName)),
+		filepath.Join(homeDir, ".ssh", fmt.Sprintf("id_ed25519_%s", accountName)),
+	}
+
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, true, candidates
+		}
+	}
+
+	return candidates[0], false, candidates
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -28,11 +28,12 @@ var statusCmd = &cobra.Command{
 
 		// Check if SSH key exists
 		homeDir, _ := os.UserHomeDir()
-		keyPath := fmt.Sprintf("%s/.ssh/id_rsa_%s", homeDir, activeAccountName)
-		if _, err := os.Stat(keyPath); err == nil {
+		keyPath, found, candidates := resolveSSHKeyPath(homeDir, activeAccountName)
+		if found {
 			fmt.Printf("  SSH Key: %s\n", keyPath)
 		} else {
-			fmt.Printf("  SSH Key: %s\n", color.YellowString(keyPath+" (not found)"))
+			fmt.Printf("  SSH Key: %s\n", color.YellowString(fmt.Sprintf("%s or %s (not found)",
+				candidates[0], candidates[1])))
 		}
 
 		return nil

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cpuix/multigit/cmd"
 	"github.com/cpuix/multigit/internal/multigit"
-	"github.com/spf13/cobra"
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -48,29 +48,15 @@ func TestStatusCommand(t *testing.T) {
 		err := multigit.SaveConfigToFile(config, configPath)
 		require.NoError(t, err, "Failed to save config")
 
-		// Initialize config
+		// Initialize config and execute the actual status command
 		cmd.InitConfig()
+		cmd.RootCmd.SetArgs([]string{"status"})
 
-		// Create a fresh command for testing
-		rootCmd := &cobra.Command{Use: "multigit"}
-		statusCmd := &cobra.Command{
-			Use:   "status",
-			Short: "Show the currently active GitHub account",
-			RunE: func(cmd *cobra.Command, args []string) error {
-				// Get active account
-				_, _, err := multigit.GetActiveAccount()
-				if err != nil {
-					io.WriteString(w, "No active GitHub account. Use 'multigit use <account>' to set an active account.\n")
-					return nil
-				}
-				return nil
-			},
-		}
-		rootCmd.AddCommand(statusCmd)
+		oldColorOutput := color.Output
+		color.Output = w
+		defer func() { color.Output = oldColorOutput }()
 
-		// Execute the status command
-		rootCmd.SetArgs([]string{"status"})
-		err = rootCmd.Execute()
+		err = cmd.RootCmd.Execute()
 		require.NoError(t, err, "Command execution failed")
 
 		// Read command output
@@ -90,6 +76,15 @@ func TestStatusCommand(t *testing.T) {
 		os.Stdout = w
 		defer func() { os.Stdout = oldStdout }()
 
+		// Prepare SSH directory with an ED25519 key for the active account
+		sshDir := filepath.Join(tempDir, ".ssh")
+		err := os.MkdirAll(sshDir, 0700)
+		require.NoError(t, err, "Failed to create SSH directory")
+
+		edKeyPath := filepath.Join(sshDir, "id_ed25519_test-account")
+		err = os.WriteFile(edKeyPath, []byte("dummy"), 0600)
+		require.NoError(t, err, "Failed to create ED25519 key file")
+
 		// Create a config with an active account
 		config := multigit.NewConfig()
 		config.Accounts = map[string]multigit.Account{
@@ -99,39 +94,18 @@ func TestStatusCommand(t *testing.T) {
 			},
 		}
 		config.ActiveAccount = "test-account"
-		err := multigit.SaveConfigToFile(config, configPath)
+		err = multigit.SaveConfigToFile(config, configPath)
 		require.NoError(t, err, "Failed to save config")
 
-		// Initialize config
+		// Initialize config and execute the actual status command
 		cmd.InitConfig()
+		cmd.RootCmd.SetArgs([]string{"status"})
 
-		// Create a fresh command for testing
-		rootCmd := &cobra.Command{Use: "multigit"}
-		statusCmd := &cobra.Command{
-			Use:   "status",
-			Short: "Show the currently active GitHub account",
-			RunE: func(cmd *cobra.Command, args []string) error {
-				// Get active account
-				activeAccountName, account, err := multigit.GetActiveAccount()
-				if err != nil {
-					io.WriteString(w, "No active GitHub account. Use 'multigit use <account>' to set an active account.\n")
-					return nil
-				}
+		oldColorOutput := color.Output
+		color.Output = w
+		defer func() { color.Output = oldColorOutput }()
 
-				// Print active account info
-				io.WriteString(w, "Active GitHub account:\n")
-				io.WriteString(w, "  Name:  "+activeAccountName+"\n")
-				io.WriteString(w, "  Email: "+account.Email+"\n")
-				io.WriteString(w, "  SSH Key: ~/.ssh/id_ed25519_"+activeAccountName+"\n")
-
-				return nil
-			},
-		}
-		rootCmd.AddCommand(statusCmd)
-
-		// Execute the status command
-		rootCmd.SetArgs([]string{"status"})
-		err = rootCmd.Execute()
+		err = cmd.RootCmd.Execute()
 		require.NoError(t, err, "Command execution failed")
 
 		// Read command output
@@ -144,6 +118,7 @@ func TestStatusCommand(t *testing.T) {
 		assert.Contains(t, output, "Active GitHub account", "Output should indicate an active account")
 		assert.Contains(t, output, "test-account", "Output should contain the account name")
 		assert.Contains(t, output, "test@example.com", "Output should contain the account email")
-		assert.Contains(t, output, "SSH Key", "Output should mention the SSH key")
+		assert.Contains(t, output, edKeyPath, "Output should report the ED25519 SSH key path")
+		assert.NotContains(t, output, "not found", "Output should not report missing keys for existing ED25519 key")
 	})
 }


### PR DESCRIPTION
## Summary
- add a shared helper that locates RSA or ED25519 SSH keys for an account
- update the list and status commands to report whichever key exists or highlight both candidate paths when missing
- expand list and status command tests to exercise ED25519-backed accounts and capture colorized output

## Testing
- go test ./cmd -run TestListCommand
- go test ./cmd -run TestStatusCommand

------
https://chatgpt.com/codex/tasks/task_e_68cbe26ceb04832a9ef519db99a6c477