### PR TITLE
Fix git config key resolution and stabilize tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /multigit ./cmd/multigit
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /multigit ./
 
 # Final stage
 FROM alpine:3.18

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ lint:
 
 # Build the binary
 build:
-	$(GOBUILD) -o $(BINARY_NAME) -v ./cmd/multigit
+        $(GOBUILD) -o $(BINARY_NAME) -v ./
 
 # Install dependencies
 deps:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ multigit create work-account name.surname@company.com
 multigit create personal me@mydomain.com -p "strong-password"
 ```
 
+> **Note:** Multigit creates modern ED25519 SSH keys by default and stores them at
+> `~/.ssh/id_ed25519_<account_name>`. If you previously generated an RSA key for
+> the same account, Multigit automatically detects it when listing accounts or
+> configuring Git.
+
 ### Switching Between Accounts
 
 ```bash

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -50,5 +50,5 @@ This will:
 
 func init() {
 	RootCmd.AddCommand(deleteCmd)
-	deleteCmd.Flags().BoolP("force", "f", false, "Force deletion without confirmation")
+	deleteCmd.Flags().BoolVarP(&forceDelete, "force", "f", false, "Force deletion without confirmation")
 }

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -44,13 +44,18 @@ func TestFullWorkflow(t *testing.T) {
 
 	// Create a mock SSH implementation
 	mockSSH := new(MockSSH)
-	
+
 	// Save original SSH client
 	oldSSHClient := multigit.SSHClient
+	oldAddToAgent := cmd.SSHAddToAgentFunc
+	cmd.SSHAddToAgentFunc = func(accountName string) error { return nil }
 	// Replace with our mock
 	multigit.SSHClient = mockSSH
 	// Restore original client after test
-	defer func() { multigit.SSHClient = oldSSHClient }()
+	defer func() {
+		multigit.SSHClient = oldSSHClient
+		cmd.SSHAddToAgentFunc = oldAddToAgent
+	}()
 
 	// Initialize config
 	cmd.InitConfig()
@@ -84,6 +89,11 @@ func TestFullWorkflow(t *testing.T) {
 		account, exists := config.Accounts["test-account"]
 		assert.True(t, exists, "Account should exist in config")
 		assert.Equal(t, "test@example.com", account.Email, "Account email should match")
+
+		keyInfo, err := ssh.ResolveKeyPath("test-account")
+		require.NoError(t, err, "Failed to resolve key path")
+		require.NoError(t, os.MkdirAll(filepath.Dir(keyInfo.Path), 0700))
+		require.NoError(t, os.WriteFile(keyInfo.Path, []byte("test-key"), 0600))
 	})
 
 	// For this integration test, we'll skip the actual git command execution
@@ -200,13 +210,18 @@ func TestErrorConditions(t *testing.T) {
 
 	// Create a mock SSH implementation
 	mockSSH := new(MockSSH)
-	
+
 	// Save original SSH client
 	oldSSHClient := multigit.SSHClient
+	oldAddToAgent := cmd.SSHAddToAgentFunc
+	cmd.SSHAddToAgentFunc = func(accountName string) error { return nil }
 	// Replace with our mock
 	multigit.SSHClient = mockSSH
 	// Restore original client after test
-	defer func() { multigit.SSHClient = oldSSHClient }()
+	defer func() {
+		multigit.SSHClient = oldSSHClient
+		cmd.SSHAddToAgentFunc = oldAddToAgent
+	}()
 
 	// Initialize config
 	cmd.InitConfig()
@@ -215,7 +230,7 @@ func TestErrorConditions(t *testing.T) {
 	t.Run("CreateAccountWithInvalidEmail", func(t *testing.T) {
 		// Initialize config
 		cmd.InitConfig()
-		
+
 		// Capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
@@ -225,7 +240,7 @@ func TestErrorConditions(t *testing.T) {
 		// Execute create command with invalid email
 		cmd.RootCmd.SetArgs([]string{"create", "test-account", "invalid-email"})
 		err := cmd.RootCmd.Execute()
-		
+
 		// Read command output (for debugging purposes)
 		w.Close()
 		var buf bytes.Buffer
@@ -243,7 +258,7 @@ func TestErrorConditions(t *testing.T) {
 	t.Run("UseNonExistentAccount", func(t *testing.T) {
 		// Initialize config
 		cmd.InitConfig()
-		
+
 		// Capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
@@ -253,7 +268,7 @@ func TestErrorConditions(t *testing.T) {
 		// Execute use command with non-existent account
 		cmd.RootCmd.SetArgs([]string{"use", "non-existent-account"})
 		err := cmd.RootCmd.Execute()
-		
+
 		// Read command output (for debugging purposes)
 		w.Close()
 		var buf bytes.Buffer
@@ -270,7 +285,7 @@ func TestErrorConditions(t *testing.T) {
 	t.Run("DeleteNonExistentAccount", func(t *testing.T) {
 		// Initialize config
 		cmd.InitConfig()
-		
+
 		// Capture stdout
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
@@ -280,7 +295,7 @@ func TestErrorConditions(t *testing.T) {
 		// Execute delete command with non-existent account
 		cmd.RootCmd.SetArgs([]string{"delete", "non-existent-account", "-f"})
 		err := cmd.RootCmd.Execute()
-		
+
 		// Read command output (for debugging purposes)
 		w.Close()
 		var buf bytes.Buffer
@@ -297,7 +312,7 @@ func TestErrorConditions(t *testing.T) {
 	t.Run("CreateDuplicateAccount", func(t *testing.T) {
 		// Initialize config
 		cmd.InitConfig()
-		
+
 		// Setup mock expectations for first create
 		mockSSH.On("CreateSSHKey", "duplicate-account", "test@example.com", "", ssh.KeyTypeED25519).Return(nil)
 		mockSSH.On("AddSSHKeyToAgent", "duplicate-account").Return(nil)
@@ -317,7 +332,7 @@ func TestErrorConditions(t *testing.T) {
 		// Try to create duplicate account
 		cmd.RootCmd.SetArgs([]string{"create", "duplicate-account", "another@example.com"})
 		err = cmd.RootCmd.Execute()
-		
+
 		// Read command output (for debugging purposes)
 		w.Close()
 		var buf bytes.Buffer

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/cpuix/multigit/internal/multigit"
+	"github.com/cpuix/multigit/internal/ssh"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -47,12 +47,13 @@ var listCmd = &cobra.Command{
 			fmt.Printf("  Email: %s\n", account.Email)
 
 			// Show SSH key info if available
-			homeDir, _ := os.UserHomeDir()
-			keyPath := fmt.Sprintf("%s/.ssh/id_rsa_%s", homeDir, name)
-			if _, err := os.Stat(keyPath); err == nil {
-				fmt.Printf("  SSH Key: %s\n", keyPath)
+			keyInfo, err := ssh.ResolveKeyPath(name)
+			if err != nil {
+				fmt.Printf("  SSH Key: %s\n", color.RedString("failed to resolve key path: %v", err))
+			} else if keyInfo.Exists {
+				fmt.Printf("  SSH Key: %s (%s)\n", keyInfo.Path, keyInfo.Type)
 			} else {
-				fmt.Printf("  SSH Key: %s (not found)\n", color.YellowString(keyPath))
+				fmt.Printf("  SSH Key: %s (not found)\n", color.YellowString(keyInfo.Path))
 			}
 
 			// Show active status

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/cpuix/multigit/internal/multigit"
+	"github.com/cpuix/multigit/internal/ssh"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +17,7 @@ var statusCmd = &cobra.Command{
 		// Get active account
 		activeAccountName, account, err := multigit.GetActiveAccount()
 		if err != nil {
-			color.Yellow("No active GitHub account. Use 'multigit use <account>' to set an active account.")
+			fmt.Println(color.YellowString("No active GitHub account. Use 'multigit use <account>' to set an active account."))
 			return nil
 		}
 
@@ -27,12 +27,13 @@ var statusCmd = &cobra.Command{
 		fmt.Printf("  Email: %s\n", color.CyanString(account.Email))
 
 		// Check if SSH key exists
-		homeDir, _ := os.UserHomeDir()
-		keyPath := fmt.Sprintf("%s/.ssh/id_rsa_%s", homeDir, activeAccountName)
-		if _, err := os.Stat(keyPath); err == nil {
-			fmt.Printf("  SSH Key: %s\n", keyPath)
+		keyInfo, err := ssh.ResolveKeyPath(activeAccountName)
+		if err != nil {
+			fmt.Printf("  SSH Key: %s\n", color.RedString("failed to resolve key path: %v", err))
+		} else if keyInfo.Exists {
+			fmt.Printf("  SSH Key: %s (%s)\n", keyInfo.Path, keyInfo.Type)
 		} else {
-			fmt.Printf("  SSH Key: %s\n", color.YellowString(keyPath+" (not found)"))
+			fmt.Printf("  SSH Key: %s\n", color.YellowString(keyInfo.Path+" (not found)"))
 		}
 
 		return nil

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cpuix/multigit/cmd"
 	"github.com/cpuix/multigit/internal/multigit"
-	"github.com/spf13/cobra"
+	"github.com/cpuix/multigit/internal/ssh"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,60 +37,35 @@ func TestStatusCommand(t *testing.T) {
 	}()
 
 	t.Run("NoActiveAccount", func(t *testing.T) {
-		// Save original stdout and restore it after the test
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
 		os.Stdout = w
 		defer func() { os.Stdout = oldStdout }()
 
-		// Create a config with no active account
 		config := multigit.NewConfig()
 		err := multigit.SaveConfigToFile(config, configPath)
 		require.NoError(t, err, "Failed to save config")
 
-		// Initialize config
 		cmd.InitConfig()
 
-		// Create a fresh command for testing
-		rootCmd := &cobra.Command{Use: "multigit"}
-		statusCmd := &cobra.Command{
-			Use:   "status",
-			Short: "Show the currently active GitHub account",
-			RunE: func(cmd *cobra.Command, args []string) error {
-				// Get active account
-				_, _, err := multigit.GetActiveAccount()
-				if err != nil {
-					io.WriteString(w, "No active GitHub account. Use 'multigit use <account>' to set an active account.\n")
-					return nil
-				}
-				return nil
-			},
-		}
-		rootCmd.AddCommand(statusCmd)
-
-		// Execute the status command
-		rootCmd.SetArgs([]string{"status"})
-		err = rootCmd.Execute()
+		cmd.RootCmd.SetArgs([]string{"status"})
+		err = cmd.RootCmd.Execute()
 		require.NoError(t, err, "Command execution failed")
 
-		// Read command output
 		w.Close()
 		var buf bytes.Buffer
 		io.Copy(&buf, r)
 		output := buf.String()
 
-		// Verify output contains expected message
 		assert.Contains(t, output, "No active GitHub account", "Output should indicate no active account")
 	})
 
 	t.Run("WithActiveAccount", func(t *testing.T) {
-		// Save original stdout and restore it after the test
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
 		os.Stdout = w
 		defer func() { os.Stdout = oldStdout }()
 
-		// Create a config with an active account
 		config := multigit.NewConfig()
 		config.Accounts = map[string]multigit.Account{
 			"test-account": {
@@ -102,48 +77,27 @@ func TestStatusCommand(t *testing.T) {
 		err := multigit.SaveConfigToFile(config, configPath)
 		require.NoError(t, err, "Failed to save config")
 
-		// Initialize config
+		// Ensure the SSH key path exists so the command reports it as present
+		keyInfo, err := ssh.ResolveKeyPath("test-account")
+		require.NoError(t, err, "Failed to resolve key path")
+		require.NoError(t, os.MkdirAll(filepath.Dir(keyInfo.Path), 0700))
+		require.NoError(t, os.WriteFile(keyInfo.Path, []byte("test-key"), 0600))
+
 		cmd.InitConfig()
 
-		// Create a fresh command for testing
-		rootCmd := &cobra.Command{Use: "multigit"}
-		statusCmd := &cobra.Command{
-			Use:   "status",
-			Short: "Show the currently active GitHub account",
-			RunE: func(cmd *cobra.Command, args []string) error {
-				// Get active account
-				activeAccountName, account, err := multigit.GetActiveAccount()
-				if err != nil {
-					io.WriteString(w, "No active GitHub account. Use 'multigit use <account>' to set an active account.\n")
-					return nil
-				}
-
-				// Print active account info
-				io.WriteString(w, "Active GitHub account:\n")
-				io.WriteString(w, "  Name:  "+activeAccountName+"\n")
-				io.WriteString(w, "  Email: "+account.Email+"\n")
-				io.WriteString(w, "  SSH Key: ~/.ssh/id_ed25519_"+activeAccountName+"\n")
-
-				return nil
-			},
-		}
-		rootCmd.AddCommand(statusCmd)
-
-		// Execute the status command
-		rootCmd.SetArgs([]string{"status"})
-		err = rootCmd.Execute()
+		cmd.RootCmd.SetArgs([]string{"status"})
+		err = cmd.RootCmd.Execute()
 		require.NoError(t, err, "Command execution failed")
 
-		// Read command output
 		w.Close()
 		var buf bytes.Buffer
 		io.Copy(&buf, r)
 		output := buf.String()
 
-		// Verify output contains expected account information
 		assert.Contains(t, output, "Active GitHub account", "Output should indicate an active account")
 		assert.Contains(t, output, "test-account", "Output should contain the account name")
 		assert.Contains(t, output, "test@example.com", "Output should contain the account email")
-		assert.Contains(t, output, "SSH Key", "Output should mention the SSH key")
+		assert.Contains(t, output, keyInfo.Path, "Output should mention the SSH key path")
+		assert.Contains(t, output, string(ssh.KeyTypeED25519), "Output should mention the key type")
 	})
 }

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -50,7 +50,7 @@ This will:
 		}
 
 		// Set git config
-		if err := setGitConfig(account, useLocal); err != nil {
+		if err := setGitConfig(accountName, account, useLocal); err != nil {
 			return fmt.Errorf("failed to set git config: %w", err)
 		}
 
@@ -66,37 +66,42 @@ This will:
 }
 
 // setGitConfig sets the git user name and email (global or local)
-func setGitConfig(account multigit.Account, local bool) error {
-	// Prepare git config args
-	configArgs := []string{"config"}
-	if !local {
-		configArgs = append(configArgs, "--global")
+func setGitConfig(accountName string, account multigit.Account, local bool) error {
+	scope := "--global"
+	if local {
+		if !IsGitRepo() {
+			return fmt.Errorf("--local flag requires running inside a git repository")
+		}
+		scope = "--local"
 	}
 
-	// Set git config
-	if err := RunGitCommand(append(configArgs, "user.name", account.Name)...); err != nil {
+	if err := RunGitCommand("config", scope, "user.name", account.Name); err != nil {
 		return fmt.Errorf("failed to set git user name: %w", err)
 	}
 
-	if err := RunGitCommand(append(configArgs, "user.email", account.Email)...); err != nil {
+	if err := RunGitCommand("config", scope, "user.email", account.Email); err != nil {
 		return fmt.Errorf("failed to set git email: %w", err)
 	}
 
-	// Only set URL rewrite for global config
 	if !local {
-		if err := RunGitCommand(append(configArgs, "url.ssh://git@github.com/.insteadOf", "https://github.com/")...); err != nil {
+		if err := RunGitCommand("config", "--global", "url.ssh://git@github.com/.insteadOf", "https://github.com/"); err != nil {
 			return fmt.Errorf("failed to set git URL rewrite: %w", err)
+		}
+		if err := RunGitCommand("config", "--global", "push.default", "current"); err != nil {
+			return fmt.Errorf("failed to set git push.default: %w", err)
 		}
 	}
 
-	// Set push default to current
-	if err := RunGitCommand("config", "--global", "push.default", "current"); err != nil {
-		return fmt.Errorf("failed to set git push.default: %w", err)
+	keyInfo, err := ssh.ResolveKeyPath(accountName)
+	if err != nil {
+		return fmt.Errorf("failed to determine SSH key path: %w", err)
+	}
+	if !keyInfo.Exists {
+		return fmt.Errorf("ssh key for account '%s' not found at %s", account.Name, keyInfo.Path)
 	}
 
-	// Set github.com to use the correct SSH key
-	sshCommand := fmt.Sprintf("ssh -i ~/.ssh/id_rsa_%s -F /dev/null", account.Name)
-	if err := RunGitCommand("config", "--global", "core.sshCommand", sshCommand); err != nil {
+	sshCommand := fmt.Sprintf("ssh -i %s -o IdentitiesOnly=yes -F /dev/null", keyInfo.Path)
+	if err := RunGitCommand("config", scope, "core.sshCommand", sshCommand); err != nil {
 		return fmt.Errorf("failed to set git core.sshCommand: %w", err)
 	}
 

--- a/cmd/use_test.go
+++ b/cmd/use_test.go
@@ -14,14 +14,15 @@ import (
 
 // testUseCommand is a test helper that sets up the test environment for the use command
 type testUseCommand struct {
-	gitCommands []string
+	gitCommands [][]string
 	isGitRepo   bool
 	t           *testing.T
 }
 
 // mockRunGitCommand mocks the RunGitCommand function for testing
 func (tuc *testUseCommand) mockRunGitCommand(args ...string) error {
-	tuc.gitCommands = append(tuc.gitCommands, args[0])
+	copied := append([]string(nil), args...)
+	tuc.gitCommands = append(tuc.gitCommands, copied)
 	tuc.t.Logf("git command: %v", args)
 	return nil
 }
@@ -35,8 +36,6 @@ func (tuc *testUseCommand) mockIsGitRepo() bool {
 // save original functions for restoration
 var originalRunGitCommand = cmd.RunGitCommand
 var originalIsGitRepo = cmd.IsGitRepo
-
-
 
 // TestUseCommand tests the use command
 func TestUseCommand(t *testing.T) {
@@ -77,8 +76,8 @@ func TestUseCommand(t *testing.T) {
 	sshDir := filepath.Join(tempDir, ".ssh")
 	require.NoError(t, os.MkdirAll(sshDir, 0700))
 
-	// Create a test SSH key
-	testSSHKeyPath := filepath.Join(sshDir, "id_rsa_test-account")
+	// Create a test SSH key (ED25519 is the default key type)
+	testSSHKeyPath := filepath.Join(sshDir, "id_ed25519_test-account")
 	require.NoError(t, os.WriteFile(testSSHKeyPath, []byte("dummy key"), 0600))
 
 	// Initialize a new config
@@ -116,6 +115,7 @@ func TestUseCommand(t *testing.T) {
 		expectCmds  int
 		expectError bool
 		errMsg      string
+		repoReady   bool
 	}{
 		{
 			name: "Switch to existing account",
@@ -132,6 +132,7 @@ func TestUseCommand(t *testing.T) {
 			local:       false,
 			expectCmds:  5, // Expect 5 git config commands for global config
 			expectError: false,
+			repoReady:   true,
 		},
 		{
 			name: "Switch to existing account with local config",
@@ -146,8 +147,26 @@ func TestUseCommand(t *testing.T) {
 				require.NoError(t, multigit.SaveConfig(config))
 			},
 			local:       true,
-			expectCmds:  4, // Expect 4 git config commands for local config
+			expectCmds:  3, // Expect 3 git config commands for local config
 			expectError: false,
+			repoReady:   true,
+		},
+		{
+			name: "Local config outside repository",
+			args: []string{"use", "test-account", "--local"},
+			setup: func() {
+				config := multigit.LoadConfig()
+				config.Accounts["test-account"] = multigit.Account{
+					Name:  "Test User",
+					Email: "test@example.com",
+				}
+				require.NoError(t, multigit.SaveConfig(config))
+			},
+			local:       true,
+			expectCmds:  0,
+			expectError: true,
+			errMsg:      "requires running inside a git repository",
+			repoReady:   false,
 		},
 		{
 			name: "Non-existent account",
@@ -162,6 +181,7 @@ func TestUseCommand(t *testing.T) {
 			expectCmds:  0, // Expect no git commands
 			expectError: true,
 			errMsg:      "account 'nonexistent' does not exist",
+			repoReady:   true,
 		},
 	}
 
@@ -188,6 +208,9 @@ func TestUseCommand(t *testing.T) {
 			// Reset command tracking
 			tuc.gitCommands = nil
 
+			// Control repo detection
+			tuc.isGitRepo = tt.repoReady
+
 			// Execute the command with the test arguments
 			cmd.RootCmd.SetArgs(tt.args)
 			err := cmd.RootCmd.Execute()
@@ -199,9 +222,21 @@ func TestUseCommand(t *testing.T) {
 				// Verify that git config was called with the correct arguments
 				assert.Equal(t, tt.expectCmds, len(tuc.gitCommands), "Expected %d git commands, got %d", tt.expectCmds, len(tuc.gitCommands))
 				// Verify all commands are 'config' commands
-				for _, cmd := range tuc.gitCommands {
-					assert.Equal(t, "config", cmd, "Expected 'config' command, got %s", cmd)
+				for _, cmdArgs := range tuc.gitCommands {
+					assert.NotEmpty(t, cmdArgs)
+					assert.Equal(t, "config", cmdArgs[0], "Expected 'config' command, got %s", cmdArgs[0])
 				}
+
+				// Verify scope of core.sshCommand setting
+				lastCmd := tuc.gitCommands[len(tuc.gitCommands)-1]
+				require.GreaterOrEqual(t, len(lastCmd), 4)
+				assert.Equal(t, "core.sshCommand", lastCmd[2], "Expected core.sshCommand to be configured")
+				if tt.local {
+					assert.Equal(t, "--local", lastCmd[1], "Local config should use --local scope")
+				} else {
+					assert.Equal(t, "--global", lastCmd[1], "Global config should use --global scope")
+				}
+				assert.Contains(t, lastCmd[3], "id_ed25519_test-account", "SSH command should reference the account key path")
 			} else {
 				// Verify no git commands were called
 				assert.Equal(t, tt.expectCmds, len(tuc.gitCommands), "Expected %d git commands, got %d", tt.expectCmds, len(tuc.gitCommands))

--- a/internal/multigit/config_test.go
+++ b/internal/multigit/config_test.go
@@ -3,13 +3,26 @@ package multigit_test
 import (
 	"encoding/json"
 	"os"
+	"os/user"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cpuix/multigit/internal/multigit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func isRootUser() bool {
+	current, err := user.Current()
+	if err != nil {
+		return false
+	}
+	if current.Uid == "0" {
+		return true
+	}
+	return strings.EqualFold(current.Username, "root")
+}
 
 // TestLoadConfigFromFile tests the LoadConfigFromFile function
 func TestLoadConfigFromFile(t *testing.T) {
@@ -60,7 +73,7 @@ func TestLoadConfigFromFile(t *testing.T) {
 
 	t.Run("Load non-existent config file", func(t *testing.T) {
 		nonExistentPath := filepath.Join(tempDir, "non_existent.json")
-		
+
 		// Ensure the file doesn't exist
 		_, err := os.Stat(nonExistentPath)
 		require.True(t, os.IsNotExist(err), "Test file should not exist")
@@ -73,7 +86,7 @@ func TestLoadConfigFromFile(t *testing.T) {
 
 	t.Run("Load invalid JSON config file", func(t *testing.T) {
 		invalidConfigPath := filepath.Join(tempDir, "invalid_config.json")
-		
+
 		// Write invalid JSON to the file
 		err := os.WriteFile(invalidConfigPath, []byte("this is not valid JSON"), 0600)
 		require.NoError(t, err, "Failed to write invalid config file")
@@ -92,7 +105,7 @@ func TestSaveConfigToFile(t *testing.T) {
 
 	t.Run("Save config to new file", func(t *testing.T) {
 		configPath := filepath.Join(tempDir, "new_config.json")
-		
+
 		// Create a test config
 		testConfig := multigit.Config{
 			Accounts: map[string]multigit.Account{
@@ -139,7 +152,7 @@ func TestSaveConfigToFile(t *testing.T) {
 
 	t.Run("Save config with invalid active references", func(t *testing.T) {
 		configPath := filepath.Join(tempDir, "invalid_refs_config.json")
-		
+
 		// Create a test config with invalid active references
 		testConfig := multigit.Config{
 			Accounts:      map[string]multigit.Account{},
@@ -169,6 +182,10 @@ func TestSaveConfigToFile(t *testing.T) {
 		// Skip this test on Windows as permissions work differently
 		if os.Getenv("OS") == "Windows_NT" {
 			t.Skip("Skipping permission test on Windows")
+		}
+
+		if isRootUser() {
+			t.Skip("Skipping permission test when running as root")
 		}
 
 		// Create a directory with no write permission

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -31,6 +31,62 @@ const (
 	// ED25519 keys are always 256 bits (32 bytes) when using the standard implementation
 )
 
+// KeyInfo describes an SSH private key on disk
+type KeyInfo struct {
+	Path   string
+	Type   KeyType
+	Exists bool
+}
+
+// DefaultKeyPath returns the default key path for the given account and key type.
+func DefaultKeyPath(accountName string, keyType KeyType) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	sanitized := filepath.Base(accountName)
+	if sanitized == "." || sanitized == "" {
+		sanitized = accountName
+	}
+
+	var fileName string
+	switch keyType {
+	case KeyTypeRSA:
+		fileName = fmt.Sprintf("id_rsa_%s", sanitized)
+	case KeyTypeED25519, "":
+		fileName = fmt.Sprintf("id_ed25519_%s", sanitized)
+	default:
+		return "", fmt.Errorf("unsupported key type: %s", keyType)
+	}
+
+	return filepath.Join(homeDir, ".ssh", fileName), nil
+}
+
+// ResolveKeyPath tries to find an existing SSH key for the given account.
+// It prefers ED25519 keys but falls back to RSA if necessary. When no key
+// is found, it returns the default ED25519 path with Exists set to false.
+func ResolveKeyPath(accountName string) (*KeyInfo, error) {
+	edPath, err := DefaultKeyPath(accountName, KeyTypeED25519)
+	if err != nil {
+		return nil, err
+	}
+	rsaPath, err := DefaultKeyPath(accountName, KeyTypeRSA)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := os.Stat(edPath); err == nil {
+		return &KeyInfo{Path: edPath, Type: KeyTypeED25519, Exists: true}, nil
+	}
+
+	if _, err := os.Stat(rsaPath); err == nil {
+		return &KeyInfo{Path: rsaPath, Type: KeyTypeRSA, Exists: true}, nil
+	}
+
+	return &KeyInfo{Path: edPath, Type: KeyTypeED25519, Exists: false}, nil
+}
+
 // MarshalED25519PrivateKey converts an ED25519 private key to OpenSSH format
 func MarshalED25519PrivateKey(key ed25519.PrivateKey, comment string) []byte {
 	// The public key is the last 32 bytes of the private key
@@ -145,24 +201,17 @@ func CreateSSHKey(accountName, accountEmail, keyFile string, keyType KeyType) er
 
 	// If keyFile is not provided, use default location in .ssh directory
 	if keyFile == "" {
-		homeDir, err := os.UserHomeDir()
+		defaultPath, err := DefaultKeyPath(accountName, keyType)
 		if err != nil {
-			return fmt.Errorf("failed to get home directory: %w", err)
+			return err
 		}
 
 		// Create .ssh directory if it doesn't exist
-		sshDir := filepath.Join(homeDir, ".ssh")
-		if err := os.MkdirAll(sshDir, 0700); err != nil {
+		if err := os.MkdirAll(filepath.Dir(defaultPath), 0700); err != nil {
 			return fmt.Errorf("failed to create .ssh directory: %w", err)
 		}
 
-		// Generate default key file path based on key type
-		switch keyType {
-		case KeyTypeRSA:
-			keyFile = filepath.Join(sshDir, fmt.Sprintf("id_rsa_%s", accountName))
-		case KeyTypeED25519:
-			keyFile = filepath.Join(sshDir, fmt.Sprintf("id_ed25519_%s", accountName))
-		}
+		keyFile = defaultPath
 	} else {
 		// Ensure parent directory exists
 		parentDir := filepath.Dir(keyFile)
@@ -291,12 +340,15 @@ func AddSSHKeyToAgent(accountOrKeyFile string) error {
 	if filepath.IsAbs(accountOrKeyFile) || strings.HasPrefix(accountOrKeyFile, ".") || strings.Contains(accountOrKeyFile, "/") {
 		privateKeyFile = accountOrKeyFile
 	} else {
-		// Otherwise, treat it as an account name and look for the key in the default location
-		homeDir, err := os.UserHomeDir()
+		// Otherwise, treat it as an account name and look for an existing key
+		keyInfo, err := ResolveKeyPath(accountOrKeyFile)
 		if err != nil {
-			return fmt.Errorf("failed to get home directory: %w", err)
+			return fmt.Errorf("failed to resolve key path: %w", err)
 		}
-		privateKeyFile = filepath.Join(homeDir, ".ssh", fmt.Sprintf("id_ed25519_%s", accountOrKeyFile))
+		if !keyInfo.Exists {
+			return fmt.Errorf("private key file %s does not exist", keyInfo.Path)
+		}
+		privateKeyFile = keyInfo.Path
 	}
 
 	// Convert to absolute path for consistent error messages
@@ -336,18 +388,14 @@ func AddSSHConfigEntry(accountName string) error {
 
 	sshConfigFile := filepath.Join(homeDir, ".ssh", "config")
 
-	// Check for both RSA and ED25519 key files
-	rsaKeyFile := filepath.Join(homeDir, ".ssh", fmt.Sprintf("id_rsa_%s", accountName))
-	ed25519KeyFile := filepath.Join(homeDir, ".ssh", fmt.Sprintf("id_ed25519_%s", accountName))
-
-	var privateKeyFile string
-	if _, err := os.Stat(rsaKeyFile); err == nil {
-		privateKeyFile = rsaKeyFile
-	} else if _, err := os.Stat(ed25519KeyFile); err == nil {
-		privateKeyFile = ed25519KeyFile
-	} else {
-		return fmt.Errorf("no SSH key found for account %s", accountName)
+	keyInfo, err := ResolveKeyPath(accountName)
+	if err != nil {
+		return fmt.Errorf("failed to resolve key path: %w", err)
 	}
+	if !keyInfo.Exists {
+		return fmt.Errorf("no SSH key found for account %s (expected at %s)", accountName, keyInfo.Path)
+	}
+	privateKeyFile := keyInfo.Path
 
 	// Read existing config with atomic operation
 	var configData []byte

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -29,6 +30,17 @@ var (
 		return ssh.ValidatePrivateKey(keyData)
 	}
 )
+
+func isRootUser() bool {
+	current, err := user.Current()
+	if err != nil {
+		return false
+	}
+	if current.Uid == "0" {
+		return true
+	}
+	return strings.EqualFold(current.Username, "root")
+}
 
 // mockCommand is used to mock exec.Command
 func mockCommand(command string, success bool) ssh.CommandRunner {
@@ -221,6 +233,7 @@ func TestDeleteSSHKey(t *testing.T) {
 		expectError bool
 		useFileFunc bool // Whether to use DeleteSSHKeyFile instead of DeleteSSHKey
 		fileTypes   []ssh.KeyType
+		skipIfRoot  bool
 	}{
 		{
 			name: "Delete existing RSA key by account name",
@@ -341,11 +354,16 @@ func TestDeleteSSHKey(t *testing.T) {
 			},
 			expectError: true,
 			useFileFunc: true,
+			skipIfRoot:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.skipIfRoot && isRootUser() {
+				t.Skip("Skipping permission-dependent test when running as root")
+			}
+
 			tempDir := t.TempDir()
 
 			// Override home directory for this test
@@ -608,6 +626,7 @@ func TestDeleteSSHKeyFile(t *testing.T) {
 		setup       func(t *testing.T, tempDir string) (string, []string) // returns keyFile and list of files that should exist
 		expectError bool
 		expectFiles []string // files that should exist after the operation
+		skipIfRoot  bool
 	}{
 		{
 			name: "Delete existing key file",
@@ -641,11 +660,11 @@ func TestDeleteSSHKeyFile(t *testing.T) {
 				// Create only a public key file
 				keyFile := filepath.Join(tempDir, "id_rsa_public_only")
 				pubKeyFile := keyFile + ".pub"
-				
+
 				// Create a dummy public key file
 				err := os.WriteFile(pubKeyFile, []byte("ssh-rsa AAAAB3NzaC1yc2E test@example.com"), 0644)
 				require.NoError(t, err, "Failed to create test public key")
-				
+
 				return keyFile, []string{
 					pubKeyFile,
 				}
@@ -660,21 +679,22 @@ func TestDeleteSSHKeyFile(t *testing.T) {
 				keyDir := filepath.Join(tempDir, "key_dir")
 				err := os.MkdirAll(keyDir, 0700)
 				require.NoError(t, err, "Failed to create directory")
-				
+
 				// Make it inaccessible to cause a stat error
 				err = os.Chmod(keyDir, 0000) // No permissions
 				require.NoError(t, err, "Failed to set directory permissions")
-				
+
 				t.Cleanup(func() {
 					// Restore permissions for cleanup
 					os.Chmod(keyDir, 0700)
 				})
-				
+
 				keyFile := filepath.Join(keyDir, "id_rsa")
 				return keyFile, []string{}
 			},
 			expectError: true,
 			expectFiles: []string{},
+			skipIfRoot:  true,
 		},
 		{
 			name: "Error checking public key file",
@@ -683,18 +703,18 @@ func TestDeleteSSHKeyFile(t *testing.T) {
 				keyFile := filepath.Join(tempDir, "id_rsa_error")
 				err := os.WriteFile(keyFile, []byte("dummy private key"), 0600)
 				require.NoError(t, err, "Failed to create test key")
-				
+
 				// Create a directory with the same name as the public key file
 				pubKeyDir := keyFile + ".pub"
 				err = os.MkdirAll(pubKeyDir, 0700)
 				require.NoError(t, err, "Failed to create directory")
-				
+
 				// Create a file inside the directory to ensure os.Remove fails
 				// (can't remove non-empty directory)
 				dummyFile := filepath.Join(pubKeyDir, "dummy")
 				err = os.WriteFile(dummyFile, []byte("dummy"), 0600)
 				require.NoError(t, err, "Failed to create dummy file")
-				
+
 				return keyFile, []string{
 					keyFile,
 					pubKeyDir,
@@ -730,11 +750,16 @@ func TestDeleteSSHKeyFile(t *testing.T) {
 			},
 			expectError: true,
 			expectFiles: []string{"id_rsa_protected", "id_rsa_protected.pub"}, // Files should still exist
+			skipIfRoot:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.skipIfRoot && isRootUser() {
+				t.Skip("Skipping permission-dependent test when running as root")
+			}
+
 			tempDir := t.TempDir()
 
 			// Setup test case
@@ -849,6 +874,44 @@ func TestValidatePrivateKey(t *testing.T) {
 	})
 }
 
+func TestResolveKeyPath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", oldHome)
+
+	info, err := ssh.ResolveKeyPath("example")
+	require.NoError(t, err)
+	assert.False(t, info.Exists)
+
+	expectedEd, err := ssh.DefaultKeyPath("example", ssh.KeyTypeED25519)
+	require.NoError(t, err)
+	assert.Equal(t, expectedEd, info.Path)
+	assert.Equal(t, ssh.KeyTypeED25519, info.Type)
+
+	rsaPath, err := ssh.DefaultKeyPath("example", ssh.KeyTypeRSA)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(rsaPath), 0700))
+	require.NoError(t, os.WriteFile(rsaPath, []byte("rsa"), 0600))
+
+	info, err = ssh.ResolveKeyPath("example")
+	require.NoError(t, err)
+	assert.True(t, info.Exists)
+	assert.Equal(t, rsaPath, info.Path)
+	assert.Equal(t, ssh.KeyTypeRSA, info.Type)
+
+	edPath, err := ssh.DefaultKeyPath("example", ssh.KeyTypeED25519)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(edPath, []byte("ed"), 0600))
+
+	info, err = ssh.ResolveKeyPath("example")
+	require.NoError(t, err)
+	assert.True(t, info.Exists)
+	assert.Equal(t, edPath, info.Path)
+	assert.Equal(t, ssh.KeyTypeED25519, info.Type)
+}
+
 func TestAddSSHKeyToAgent(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -943,7 +1006,7 @@ func TestAddSSHKeyToAgent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Reset SSH_AUTH_SOCK to default for each test case
 			os.Setenv("SSH_AUTH_SOCK", "/tmp/ssh-agent.sock")
-			
+
 			// Setup test case
 			tc.setup()
 


### PR DESCRIPTION
## Summary
- ensure `multigit use` resolves SSH keys with the account identifier and configures git scope correctly
- align CLI output and tests with the ED25519 default key naming and improve status messaging
- harden SSH cleanup tests by skipping permission scenarios when running as root

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cc34525d84832ab7a6be7154b6c08a